### PR TITLE
Include different packages for different frontends

### DIFF
--- a/build_frontends.sh
+++ b/build_frontends.sh
@@ -73,13 +73,6 @@ while [[ "$#" -gt 0 ]]; do
     shift
 done
 
-# Set TT_THOMAS_FRONTEND if ffe or xla exclusively is set to true
-if [ "$tt_forge_fe" = true ] && [ "$tt_xla" = false ]; then
-    export TT_THOMAS_FRONTEND="tt-forge-fe"
-elif [ "$tt_xla" = true ] && [ "$tt_forge_fe" = false ]; then
-    export TT_THOMAS_FRONTEND="tt-xla"
-fi
-
 # Set the toolchain directory
 # This directory is used to store the toolchains for the different frontends
 if [ -z "$TOOLCHAIN_DIR" ]; then
@@ -122,7 +115,10 @@ if [ "$tt_forge_fe" = true ]; then
     fi
     build_tt_forge_fe
 
+    export TT_THOMAS_FRONTEND="tt-forge-fe"
     install_tt_thomas
+    unset TT_THOMAS_FRONTEND
+
     sudo unlink /opt/ttmlir-toolchain
 fi
 
@@ -147,6 +143,8 @@ if [ "$tt_xla" = true ]; then
     sudo ln -s "$TOOLCHAIN_DIR/tt-xla/ttmlir-toolchain" /opt/
 
     build_tt_xla
+    export TT_THOMAS_FRONTEND="tt-xla"
     install_tt_thomas
+    unset TT_THOMAS_FRONTEND
     sudo unlink /opt/ttmlir-toolchain
 fi

--- a/setup.py
+++ b/setup.py
@@ -9,21 +9,26 @@ import os
 # Frontends can be tt-forge-fe or tt-xla
 FRONTEND = os.environ.get("TT_THOMAS_FRONTEND", "")
 if not FRONTEND:
-    print("Warning: TT_THOMAS_FRONTEND environment variable not set. All packages will be included.")
+    print("Error: TT_THOMAS_FRONTEND environment variable not set.")
+    exit(1)
 
 
-exclude_keywords = defaultdict(list)
-exclude_keywords.update(
+exclude_keywords = defaultdict(
+    list,
     {
         "tt-forge-fe": ["jax"],
         "tt-xla": ["forge", "torch", "lightning", "torchvision"],
-    }
+    },
 )
 
+
 all_packages = find_packages(include=["thomas*"])
-excluded_packages = [
-    pkg for pkg in all_packages if any([re.search(keyword, pkg) for keyword in exclude_keywords[FRONTEND]])
-]
+excluded_packages = []
+for pkg in all_packages:
+    for keyword in exclude_keywords[FRONTEND]:
+        if re.search(keyword, pkg):
+            excluded_packages.append(pkg)
+            break
 
 setup(
     name="thomas",


### PR DESCRIPTION
When installing tt-thomas, different subpackages should be included depending on the frontend.

Closes #53