### PR TITLE
Add DoRA training option for Llama

### DIFF
--- a/blacksmith/experiments/torch/llama/README.md
+++ b/blacksmith/experiments/torch/llama/README.md
@@ -13,8 +13,16 @@ NOTE:  LLaMA fine-tuning currently utilizes GPUs. We are actively working on ena
 
 ## Training
 
+Run the default LoRA configuration:
+
 ```bash
-python3 blacksmith/experiments/pytorch/llama/test_llama_fine_tuning.py
+python3 blacksmith/experiments/torch/llama/test_llama_fine_tuning.py
+```
+
+To fine-tune using DoRA, provide the DoRA config file:
+
+```bash
+python3 blacksmith/experiments/torch/llama/test_llama_fine_tuning.py --config test_llama_fine_tuning_dora.yaml
 ```
 
 ## Data

--- a/blacksmith/experiments/torch/llama/configs.py
+++ b/blacksmith/experiments/torch/llama/configs.py
@@ -26,6 +26,7 @@ class TrainingConfig(BaseModel):
     lora_alpha: int = Field(default=8, gt=0)
     lora_target_modules: list[str] = Field(default_factory=lambda: ["all-linear"])
     lora_task_type: str = Field(default="CAUSAL_LM")
+    use_dora: bool = Field(default=False)
 
     # Other settings
     seed: int = Field(default=23)

--- a/blacksmith/experiments/torch/llama/test_llama_fine_tuning.py
+++ b/blacksmith/experiments/torch/llama/test_llama_fine_tuning.py
@@ -4,6 +4,7 @@
 import os
 import re
 import json
+import argparse
 import torch
 import wandb
 from tqdm import tqdm
@@ -129,7 +130,11 @@ def evaluate(model, tokenizer, eval_set):
 
 
 if __name__ == "__main__":
-    config_file_path = os.path.join(os.path.dirname(__file__), "test_llama_fine_tuning.yaml")
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--config", type=str, default="test_llama_fine_tuning.yaml")
+    args = parser.parse_args()
+
+    config_file_path = os.path.join(os.path.dirname(__file__), args.config)
     config = generate_config(TrainingConfig, config_file_path)
 
     model = get_model(config)

--- a/blacksmith/experiments/torch/llama/test_llama_fine_tuning_dora.yaml
+++ b/blacksmith/experiments/torch/llama/test_llama_fine_tuning_dora.yaml
@@ -1,0 +1,37 @@
+# Dataset settings
+dataset_id: "stanfordnlp/sst2"
+
+# Model settings
+model_name: "meta-llama/Llama-3.2-1B"
+max_length: 128
+dtype: "torch.bfloat16"
+
+# Training hyperparameters
+learning_rate: 2e-5
+batch_size: 32
+gradient_accumulation_steps: 1
+gradient_checkpointing: False
+num_epochs: 1
+optim: "adamw_torch"
+
+# DoRA setup
+lora_r: 4
+lora_alpha: 8
+lora_dropout: 0.1
+lora_bias: "none"
+lora_target_modules: "all-linear"
+use_dora: True
+
+# Other settings
+seed: 23
+output_dir: "path/to/dir"
+report_to: "wandb"
+wandb_project: "llama-finetuning"
+wandb_watch_mode: "all"
+wandb_log_freq: 1000
+save_strategy: "epoch"
+logging_strategy: "steps"
+logging_steps: 10
+save_total_limit: 3
+do_train: True
+do_eval: False

--- a/blacksmith/models/torch/huggingface/hf_models.py
+++ b/blacksmith/models/torch/huggingface/hf_models.py
@@ -39,6 +39,7 @@ def get_model(config: TrainingConfig):
         target_modules=config.lora_target_modules,
         layers_to_transform=ltt,
         task_type=config.lora_task_type,
+        use_dora=config.use_dora,
     )
     model = get_peft_model(model, lora_config)
     model.to(eval(config.dtype))


### PR DESCRIPTION
### Ticket
fixes #236 

### What's changed
- Introduced a use_dora flag in the training configuration to enable DoRA-based fine-tuning alongside existing LoRA parameters 
- Passed the new flag to PEFT’s LoraConfig, allowing the model loader to activate DoRA during model construction
- Updated the fine-tuning script to accept a --config argument so custom DoRA YAML files can be selected at runtime
- Added a dedicated DoRA configuration file and expanded the README with instructions for running DoRA training

### Checklist
- [ ] New/Existing tests provide coverage for changes
