### PR TITLE
Fix gif path and initial letters of repo names

### DIFF
--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -57,4 +57,4 @@ This section guides you through the process of running experiments included in t
 
 ## Visual Demo: 3D Reconstruction with NeRF
 
-<img src="imgs/nerf_demo.gif" alt="nerf demo" height="230"/>
+<img src="./imgs/nerf_demo.gif" alt="nerf demo" height="230"/>

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -1,6 +1,6 @@
 # Introduction
 
-The **TT-Blacksmith** project contains optimized training recipes for a variety of machine learning models on [Tenstorrent](https://tenstorrent.com/) hardware, powered by the [tt-forge](https://github.com/tenstorrent/tt-forge) compiler stack. Showcasing the compiler's flexibility, it enables the use of popular [AI frameworks](https://github.com/tenstorrent/tt-forge?tab=readme-ov-file#current-ai-framework-front-end-projects) like PyTorch and JAX for training workflows.
+The **TT-Blacksmith** project contains optimized training recipes for a variety of machine learning models on [Tenstorrent](https://tenstorrent.com/) hardware, powered by the [TT-Forge](https://github.com/tenstorrent/tt-forge) compiler stack. Showcasing the compiler's flexibility, it enables the use of popular [AI frameworks](https://github.com/tenstorrent/tt-forge?tab=readme-ov-file#current-ai-framework-front-end-projects) like PyTorch and JAX for training workflows.
 
 The main goal of this project are:
 - **Demonstrations:** Practical examples and workflows showcasing how to train various ML models on Tenstorrent hardware.

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -1,6 +1,6 @@
 # Introduction
 
-The **tt-blacksmith** project contains optimized training recipes for a variety of machine learning models on [Tenstorrent](https://tenstorrent.com/) hardware, powered by the [tt-forge](https://github.com/tenstorrent/tt-forge) compiler stack. Showcasing the compiler's flexibility, it enables the use of popular [AI frameworks](https://github.com/tenstorrent/tt-forge?tab=readme-ov-file#current-ai-framework-front-end-projects) like PyTorch and JAX for training workflows.
+The **TT-Blacksmith** project contains optimized training recipes for a variety of machine learning models on [Tenstorrent](https://tenstorrent.com/) hardware, powered by the [tt-forge](https://github.com/tenstorrent/tt-forge) compiler stack. Showcasing the compiler's flexibility, it enables the use of popular [AI frameworks](https://github.com/tenstorrent/tt-forge?tab=readme-ov-file#current-ai-framework-front-end-projects) like PyTorch and JAX for training workflows.
 
 The main goal of this project are:
 - **Demonstrations:** Practical examples and workflows showcasing how to train various ML models on Tenstorrent hardware.


### PR DESCRIPTION
### Ticket
Docs issue

### Problem description
Gif file is not showing on documentation

### What's changed
We need a relative path so that we can get the gif displayed.

### Checklist
- [ ] New/Existing tests provide coverage for changes
