### PR TITLE
add deepwiki badge to tt-blacksmith

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/tenstorrent/tt-blacksmith)
+
 <div align="center">
 
 <h1>


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-forge/issues/327?issue=tenstorrent%7Ctt-forge%7C449)

### Problem description
We have a deepwiki page for TT-Blacksmith and that isn't apparent from viewing the repo.

### What's changed
Describe the approach used to solve the problem.
Add a deepwiki badge to the TT-Blacksmith readme so developers know we offer this. 

### Checklist
- [ ] New/Existing tests provide coverage for changes
