### PR TITLE
[Temporary] Downgrade equinox version to support jax 0.7.1

### DIFF
--- a/blacksmith/experiments/jax/llama/README.md
+++ b/blacksmith/experiments/jax/llama/README.md
@@ -15,9 +15,8 @@ This directory includes:
 
 ```bash
 pip install git+https://github.com/patrick-kidger/quax.git@8c50184a7e60835799cc5f79c9de9315ca77c875 --no-deps
-pip install equinox==0.13.1 --no-deps
+pip install git+https://github.com/patrick-kidger/equinox.git@367124071570194b5d90692b2e09caa834b89ab9 --no-deps
 pip install plum-dispatch==2.5.7 beartype==0.21.0 rich==14.1.0
-export PYTHONPATH=/localdev/upantelic/tt-blacksmith:$PYTHONPATH
 ```
 
 ## Usage


### PR DESCRIPTION
[Equinox](https://github.com/patrick-kidger/equinox) library introduced a [commit](https://github.com/patrick-kidger/equinox/commit/f1a316197811918754a3386bed346b1e2a402d54) that deprecates Jax versions 0.7.0 and 0.7.1.

If lorax dependency libraries are installed by following the current instructions, installation fails, given that our pjrt-plugin is still on version Jax 0.7.1

As a temporary solution I'm replacing current Equinox version with the commit one before the problematic one and once our plugin starts supporting Jax 0.7.2, we will migrate to more regular library versioning.