### PR TITLE
Fix tables containing config params in README file for some models

### DIFF
--- a/blacksmith/experiments/torch/llama/xla/README.md
+++ b/blacksmith/experiments/torch/llama/xla/README.md
@@ -70,7 +70,6 @@ Current `test_llama_fine_tuning_pure_torch.yaml` has the recommended and tested 
 | `model_to_wandb`              | Whether to store model checkpoint in Weights & Biases. | False                               |
 | `steps_freq`                  | Frequency (in steps) for performing periodic actions.  | 25                                  |
 | `epoch_freq`                  | Frequency (in epochs) for performing periodic actions. | 1                                   |
-
 | `resume_from_checkpoint`      | Whether to resume training from a previous checkpoint. | False                               |
 | `resume_option`               | Resume method (`last`, `best`, or `path`).             | "last"                              |
 | `checkpoint_path`             | Path to a checkpoint if `resume_option="path"`.        | ""                                  |
@@ -81,7 +80,6 @@ Current `test_llama_fine_tuning_pure_torch.yaml` has the recommended and tested 
 | `sync_to_storage`             | Whether to sync checkpoints to remote storage.         | False                               |
 | `load_from_storage`           | Whether to load checkpoints from remote storage.       | False                               |
 | `remote_path`                 | Remote storage path (if applicable).                   | ""                                  |
-
 | `seed`                        | Random seed for reproducibility.                       | 23                                  |
 | `deterministic`               | Whether to enforce deterministic behavior.             | False                               |
 | `lora_r`                      | Rank of LoRA adaptation matrices.                      | 4                                   |

--- a/blacksmith/experiments/torch/qwen/README.md
+++ b/blacksmith/experiments/torch/qwen/README.md
@@ -69,7 +69,6 @@ Current `test_qwen_finetuning.yaml` has the recommended and tested hyperparamete
 | `model_to_wandb`              | Whether to store model checkpoint in Weights & Biases. | False                               |
 | `steps_freq`                  | Frequency (in steps) for performing periodic actions.  | 25                                  |
 | `epoch_freq`                  | Frequency (in epochs) for performing periodic actions. | 1                                   |
-
 | `resume_from_checkpoint`      | Whether to resume training from a previous checkpoint. | False                               |
 | `resume_option`               | Resume method (`last`, `best`, or `path`).             | "last"                              |
 | `checkpoint_path`             | Path to a checkpoint if `resume_option="path"`.        | ""                                  |
@@ -80,7 +79,6 @@ Current `test_qwen_finetuning.yaml` has the recommended and tested hyperparamete
 | `sync_to_storage`             | Whether to sync checkpoints to remote storage.         | False                               |
 | `load_from_storage`           | Whether to load checkpoints from remote storage.       | False                               |
 | `remote_path`                 | Remote storage path (if applicable).                   | ""                                  |
-
 | `seed`                        | Random seed for reproducibility.                       | 23                                  |
 | `deterministic`               | Whether to enforce deterministic behavior.             | False                               |
 | `lora_r`                      | Rank of LoRA adaptation matrices.                      | 4                                   |


### PR DESCRIPTION
For some models, in table containing config params there were spaces which corrupted the table look - removing those spaces in this PR.