### PR TITLE
refactor torch mnist to use device_menager

### DIFF
--- a/blacksmith/experiments/torch/mnist/test_mnist_training.py
+++ b/blacksmith/experiments/torch/mnist/test_mnist_training.py
@@ -161,7 +161,7 @@ if __name__ == "__main__":
     # Logging + checkpoints
     logger = TrainingLogger(config)
     checkpoint_manager = CheckpointManager(config, logger)
-    
+
     # Device setup
     device_manager = DeviceManager(config)
     logger.info(f"Using device: {device_manager.device}")


### PR DESCRIPTION
Refactored torch mnist to be aligned with #307, as `setup_tt_environment` has been removed in that PR\

## Tasks
- [x] ~~remove uplift from the PR, just for testing purpose~~ https://github.com/tenstorrent/tt-blacksmith/actions/runs/20170334689/job/57904097653