### PR TITLE
Uplift tt-xla to 0.7.0.dev20251218 2025-12-18

### DIFF
--- a/env/xla_requirements.txt
+++ b/env/xla_requirements.txt
@@ -1,5 +1,5 @@
 --extra-index-url https://pypi.eng.aws.tenstorrent.com
-pjrt-plugin-tt==0.7.0.dev20251217
+pjrt-plugin-tt==0.7.0.dev20251218
 flax
 six
 torchdata


### PR DESCRIPTION
This PR uplifts the tt-xla to the 0.7.0.dev20251218