### PR TITLE
Uplift tt-xla to 0.7.0.dev20251221 2025-12-21

### DIFF
--- a/env/xla_requirements.txt
+++ b/env/xla_requirements.txt
@@ -1,5 +1,5 @@
 --extra-index-url https://pypi.eng.aws.tenstorrent.com
-pjrt-plugin-tt==0.7.0.dev20251220
+pjrt-plugin-tt==0.7.0.dev20251221
 flax
 six
 torchdata


### PR DESCRIPTION
This PR uplifts the tt-xla to the 0.7.0.dev20251221