### PR TITLE
Uplift tt-xla to 0.8.0.dev20260104 2026-01-04

### DIFF
--- a/env/xla_requirements.txt
+++ b/env/xla_requirements.txt
@@ -1,5 +1,5 @@
 --extra-index-url https://pypi.eng.aws.tenstorrent.com
-pjrt-plugin-tt==0.8.0.dev20260103
+pjrt-plugin-tt==0.8.0.dev20260104
 flax
 six
 torchdata


### PR DESCRIPTION
This PR uplifts the tt-xla to the 0.8.0.dev20260104