### PR TITLE
Add `training_type` to All Experiments

### DIFF
--- a/blacksmith/experiments/torch/albert/configs.py
+++ b/blacksmith/experiments/torch/albert/configs.py
@@ -17,6 +17,7 @@ class TrainingConfig(BaseModel):
     dtype: str = Field(default="torch.bfloat16")
 
     # Training hyperparameters
+    training_type: str = Field(default="lora")  # [lora, adapters]
     learning_rate: float = Field(default=1e-3, gt=0)
     weight_decay: float = Field(default=0.0, ge=0)
     batch_size: int = Field(default=32, gt=0)

--- a/blacksmith/experiments/torch/albert/test_albert_finetuning.yaml
+++ b/blacksmith/experiments/torch/albert/test_albert_finetuning.yaml
@@ -9,6 +9,7 @@ mlp_hidden_size: 256
 dtype: "torch.bfloat16"
 
 # Training hyperparameters
+training_type: "lora"
 learning_rate: 1e-3
 weight_decay: 0.01
 batch_size: 8

--- a/blacksmith/experiments/torch/gemma/configs.py
+++ b/blacksmith/experiments/torch/gemma/configs.py
@@ -16,6 +16,7 @@ class TrainingConfig(BaseModel):
     ignored_index: int = Field(default=-100)
 
     # Training hyperparameters
+    training_type: str = Field(default="lora")  # [lora, adapters]
     learning_rate: float = Field(default=2e-5, gt=0)
     batch_size: int = Field(default=32, gt=0)
     gradient_checkpointing: bool = Field(default=False)

--- a/blacksmith/experiments/torch/gemma/test_gemma_finetuning.yaml
+++ b/blacksmith/experiments/torch/gemma/test_gemma_finetuning.yaml
@@ -8,6 +8,7 @@ dtype: "torch.bfloat16"
 ignored_index: -100
 
 # Training hyperparameters
+training_type: "lora"
 learning_rate: 6e-5
 batch_size: 8
 gradient_checkpointing: False

--- a/blacksmith/experiments/torch/gemma11/configs.py
+++ b/blacksmith/experiments/torch/gemma11/configs.py
@@ -16,6 +16,7 @@ class TrainingConfig(BaseModel):
     ignored_index: int = Field(default=-100)
 
     # Training hyperparameters
+    training_type: str = Field(default="lora")  # [lora, adapters]
     learning_rate: float = Field(default=6e-5, gt=0)
     batch_size: int = Field(default=4, gt=0)
     gradient_checkpointing: bool = Field(default=False)

--- a/blacksmith/experiments/torch/gemma11/test_gemma11_finetuning_squadV2.yaml
+++ b/blacksmith/experiments/torch/gemma11/test_gemma11_finetuning_squadV2.yaml
@@ -8,6 +8,7 @@ dtype: "torch.bfloat16"
 ignored_index: -100
 
 # Training hyperparameters
+training_type: "lora"
 learning_rate: 6e-5
 batch_size: 1
 gradient_checkpointing: False

--- a/blacksmith/experiments/torch/gemma11/test_gemma11_finetuning_sst2.yaml
+++ b/blacksmith/experiments/torch/gemma11/test_gemma11_finetuning_sst2.yaml
@@ -8,6 +8,7 @@ dtype: "torch.bfloat16"
 ignored_index: -100
 
 # Training hyperparameters
+training_type: "lora"
 learning_rate: 6e-5
 batch_size: 4
 gradient_checkpointing: False

--- a/blacksmith/experiments/torch/llama/xla/lora/galaxy/test_llama_1b.yaml
+++ b/blacksmith/experiments/torch/llama/xla/lora/galaxy/test_llama_1b.yaml
@@ -7,6 +7,7 @@ max_length: 64
 dtype: "torch.bfloat16"
 
 # Training hyperparameters
+training_type: "lora"
 learning_rate: 2e-4
 batch_size: 64
 num_epochs: 1

--- a/blacksmith/experiments/torch/llama/xla/lora/galaxy/test_llama_8b.yaml
+++ b/blacksmith/experiments/torch/llama/xla/lora/galaxy/test_llama_8b.yaml
@@ -7,6 +7,7 @@ max_length: 64
 dtype: "torch.bfloat16"
 
 # Training hyperparameters
+training_type: "lora"
 learning_rate: 2e-4
 batch_size: 64
 num_epochs: 1

--- a/blacksmith/experiments/torch/llama/xla/lora/quietbox/test_llama_1b.yaml
+++ b/blacksmith/experiments/torch/llama/xla/lora/quietbox/test_llama_1b.yaml
@@ -7,6 +7,7 @@ max_length: 64
 dtype: "torch.bfloat16"
 
 # Training hyperparameters
+training_type: "lora"
 learning_rate: 2e-4
 batch_size: 32
 num_epochs: 1

--- a/blacksmith/experiments/torch/llama/xla/lora/quietbox/test_llama_8b.yaml
+++ b/blacksmith/experiments/torch/llama/xla/lora/quietbox/test_llama_8b.yaml
@@ -7,6 +7,7 @@ max_length: 64
 dtype: "torch.bfloat16"
 
 # Training hyperparameters
+training_type: "lora"
 learning_rate: 2e-4
 batch_size: 32
 num_epochs: 1

--- a/blacksmith/experiments/torch/llama/xla/lora/single_chip/test_llama_1b.yaml
+++ b/blacksmith/experiments/torch/llama/xla/lora/single_chip/test_llama_1b.yaml
@@ -7,6 +7,7 @@ max_length: 64
 dtype: "torch.bfloat16"
 
 # Training hyperparameters
+training_type: "lora"
 learning_rate: 1e-4
 batch_size: 16
 num_epochs: 1

--- a/blacksmith/experiments/torch/phi/configs.py
+++ b/blacksmith/experiments/torch/phi/configs.py
@@ -16,6 +16,7 @@ class TrainingConfig(BaseModel):
     ignored_index: int = Field(default=-100)
 
     # Training hyperparameters
+    training_type: str = Field(default="lora")  # [lora, adapters]
     learning_rate: float = Field(default=6e-5, gt=0)
     batch_size: int = Field(default=8, gt=0)
     gradient_checkpointing: bool = Field(default=False)

--- a/blacksmith/experiments/torch/phi/test_phi15_finetuning_squadV2.yaml
+++ b/blacksmith/experiments/torch/phi/test_phi15_finetuning_squadV2.yaml
@@ -8,6 +8,7 @@ dtype: "torch.bfloat16"
 ignored_index: -100
 
 # Training hyperparameters
+training_type: "lora"
 learning_rate: 6e-5
 batch_size: 2
 gradient_checkpointing: False

--- a/blacksmith/experiments/torch/phi/test_phi15_finetuning_sst2.yaml
+++ b/blacksmith/experiments/torch/phi/test_phi15_finetuning_sst2.yaml
@@ -8,6 +8,7 @@ dtype: "torch.bfloat16"
 ignored_index: -100
 
 # Training hyperparameters
+training_type: "lora"
 learning_rate: 6e-5
 batch_size: 8
 gradient_checkpointing: False

--- a/blacksmith/experiments/torch/phi/test_phi1_finetuning_squadV2.yaml
+++ b/blacksmith/experiments/torch/phi/test_phi1_finetuning_squadV2.yaml
@@ -8,6 +8,7 @@ dtype: "torch.bfloat16"
 ignored_index: -100
 
 # Training hyperparameters
+training_type: "lora"
 learning_rate: 6e-5
 batch_size: 2
 gradient_checkpointing: False

--- a/blacksmith/experiments/torch/phi/test_phi1_finetuning_sst2.yaml
+++ b/blacksmith/experiments/torch/phi/test_phi1_finetuning_sst2.yaml
@@ -8,6 +8,7 @@ dtype: "torch.bfloat16"
 ignored_index: -100
 
 # Training hyperparameters
+training_type: "lora"
 learning_rate: 6e-5
 batch_size: 8
 gradient_checkpointing: False

--- a/blacksmith/experiments/torch/qwen/configs.py
+++ b/blacksmith/experiments/torch/qwen/configs.py
@@ -15,6 +15,7 @@ class TrainingConfig(BaseModel):
     dtype: str = Field(default="torch.bfloat16")
 
     # Training hyperparameters
+    training_type: str = Field(default="lora")  # [lora, adapters]
     learning_rate: float = Field(default=2e-5, gt=0)
     batch_size: int = Field(default=32, gt=0)
     gradient_accumulation_steps: int = Field(default=1, gt=0)

--- a/blacksmith/experiments/torch/qwen/test_qwen_1-5b_finetuning.yaml
+++ b/blacksmith/experiments/torch/qwen/test_qwen_1-5b_finetuning.yaml
@@ -7,6 +7,7 @@ max_length: 128
 dtype: "torch.bfloat16"
 
 # Training hyperparameters
+training_type: "lora"
 learning_rate: 2e-5
 batch_size: 8
 gradient_accumulation_steps: 1

--- a/blacksmith/experiments/torch/qwen/test_qwen_finetuning.yaml
+++ b/blacksmith/experiments/torch/qwen/test_qwen_finetuning.yaml
@@ -7,6 +7,7 @@ max_length: 128
 dtype: "torch.bfloat16"
 
 # Training hyperparameters
+training_type: "lora"
 learning_rate: 2e-5
 batch_size: 8
 gradient_accumulation_steps: 1


### PR DESCRIPTION
### Ticket
NA

### Problem description
After adding adapter layers method, I forgot to add `training_type` parameter to all other experiments and we end up not being able to `get_model` properly.

### What's changed
Adding training_type to other configs.

### Checklist
- [ ] Run of experiments to check that they are working properly
