### PR TITLE
Fix broken `env/activate`

### DIFF
--- a/env/activate
+++ b/env/activate
@@ -21,7 +21,7 @@ case $1 in
 esac
 
 # pytest alias for venv interpreter
-alias pytest='python3.11 -m pytest'
+alias pytest='python -m pytest'
 
 # Set environment directory based on experiment type
 case $EXPERIMENT_TYPE in
@@ -128,3 +128,5 @@ case $EXPERIMENT_TYPE in
         echo "Unknown experiment type: $EXPERIMENT_TYPE"
         return 1
 esac
+
+pip install -e $TT_BLACKSMITH_HOME


### PR DESCRIPTION
### Problem description
Uplift https://github.com/tenstorrent/tt-blacksmith/actions/runs/21057356171 was failing due to the change in env/activate. Locally it was caching pevious python package installs, so it was not failing.

### What's changed
Fixing problems in `env/activate`

### Checklist
- [x] Run CI https://github.com/tenstorrent/tt-blacksmith/actions/runs/21063219210
