### PR TITLE
Adjust dtype of MNIST models to match the config

### DIFF
--- a/blacksmith/experiments/torch/mnist/cnn/test_mnist_cnn_training.py
+++ b/blacksmith/experiments/torch/mnist/cnn/test_mnist_cnn_training.py
@@ -71,7 +71,7 @@ def train(
     model = MNISTCNN(config=config)
 
     # Convert model to specified dtype if configured
-    dtype = eval(config.dtype) if hasattr(config, "dtype") and config.dtype else torch.float32
+    dtype = eval(config.dtype) if hasattr(config, "dtype") and config.dtype else None
     model = model.to(device=device_manager.device, dtype=dtype)
 
     logger.info(f"Loaded {config.model_name} model.")

--- a/blacksmith/experiments/torch/mnist/data_parallel/test_mnist_training.py
+++ b/blacksmith/experiments/torch/mnist/data_parallel/test_mnist_training.py
@@ -66,7 +66,7 @@ def train(
     model = MNISTLinear(config.input_size, config.hidden_size, config.output_size, bias=config.bias)
 
     # Convert model to specified dtype if configured
-    dtype = eval(config.dtype) if hasattr(config, "dtype") and config.dtype else torch.float32
+    dtype = eval(config.dtype) if hasattr(config, "dtype") and config.dtype else None
     model = model.to(device=device_manager.device, dtype=dtype)
 
     logger.info(f"Loaded {config.model_name} model.")

--- a/blacksmith/experiments/torch/mnist/tensor_parallel/test_mnist_training.py
+++ b/blacksmith/experiments/torch/mnist/tensor_parallel/test_mnist_training.py
@@ -73,7 +73,7 @@ def train(
     model = MNISTLinear(config.input_size, config.hidden_size, config.output_size, bias=config.bias)
 
     # Convert model to specified dtype if configured
-    dtype = eval(config.dtype) if hasattr(config, "dtype") and config.dtype else torch.float32
+    dtype = eval(config.dtype) if hasattr(config, "dtype") and config.dtype else None
     model = model.to(device=device_manager.device, dtype=dtype)
 
     logger.info(f"Loaded {config.model_name} model.")

--- a/blacksmith/experiments/torch/mnist/test_mnist_training.py
+++ b/blacksmith/experiments/torch/mnist/test_mnist_training.py
@@ -71,7 +71,7 @@ def train(
     model = MNISTLinear(config.input_size, config.hidden_size, config.output_size, bias=config.bias)
 
     # Convert model to specified dtype if configured
-    dtype = eval(config.dtype) if hasattr(config, "dtype") and config.dtype else torch.float32
+    dtype = eval(config.dtype) if hasattr(config, "dtype") and config.dtype else None
     model = model.to(device=device_manager.device, dtype=dtype)
 
     logger.info(f"Loaded {config.model_name} model.")


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Currently, only the newest CNN MNIST experiment takes into account that the model should be switched to `torch.bfloat16` (or other depending on the .yaml config).

This PR patches other experiments to do a `model.to(dtype)` correctly.

### What's changed
Added `model.to(dtype)` to each of the MNIST experiments.
