### PR TITLE
Add Torch Compile to LLaMA Training Workloads

### DIFF
--- a/blacksmith/experiments/torch/llama/xla/test_llama_fine_tuning_pure_torch.py
+++ b/blacksmith/experiments/torch/llama/xla/test_llama_fine_tuning_pure_torch.py
@@ -98,12 +98,17 @@ def training_step_inner(batch, model, loss_fn):
 
 
 def train(
-    config: TrainingConfig, device_manager: DeviceManager, logger: TrainingLogger, checkpoint_manager: CheckpointManager
+    config: TrainingConfig,
+    device_manager: DeviceManager,
+    logger: TrainingLogger,
+    checkpoint_manager: CheckpointManager,
 ):
     logger.info("Starting training...")
 
     # Load model
     model = get_model(config, device_manager.device)
+    if config.use_tt:
+        model = torch.compile(model, backend="tt", options={"tt_enable_torch_fx_fusion_pass": False})
     logger.info(f"Loaded {config.model_name} model.")
     logger.info(f"Model parameters: {sum(p.numel() for p in model.parameters())}")
     logger.info(f"Trainable parameters: {sum(p.numel() for p in model.parameters() if p.requires_grad)}")
@@ -171,7 +176,13 @@ def train(
 
                     # Do validation.
                     valid_loss = validate(
-                        model, eval_dataloader, cross_entropy_loss, logger, device_manager.device, config, tokenizer
+                        model,
+                        eval_dataloader,
+                        cross_entropy_loss,
+                        logger,
+                        device_manager.device,
+                        config,
+                        tokenizer,
                     )
                     logger.log_metrics({"val/loss": valid_loss}, step=global_step)
 


### PR DESCRIPTION
### Issue
 #424

### What's Changed
Use torch.compile for training.

