### PR TITLE
Add Torch Compile to Qwen Training Workloads

### DIFF
--- a/blacksmith/experiments/torch/qwen/test_qwen_finetuning.py
+++ b/blacksmith/experiments/torch/qwen/test_qwen_finetuning.py
@@ -93,6 +93,8 @@ def train(
 
     # Load model
     model = get_model(config, device_manager.device)
+    if config.use_tt:
+        model = torch.compile(model, backend="tt", options={"tt_enable_torch_fx_fusion_pass": False})
     logger.info(f"Loaded {config.model_name} model.")
     logger.info(f"Model parameters: {sum(p.numel() for p in model.parameters())}")
     logger.info(f"Trainable parameters: {sum(p.numel() for p in model.parameters() if p.requires_grad)}")


### PR DESCRIPTION
### Issue
 #424

### What's Changed
Use torch.compile for training.

