### PR TITLE
Disable Experimental Compile and Unify Compilation Logic

### DIFF
--- a/blacksmith/experiments/torch/gemma/test_gemma_finetuning.py
+++ b/blacksmith/experiments/torch/gemma/test_gemma_finetuning.py
@@ -86,8 +86,7 @@ def train(
 
     # Load model
     model = get_model(config, device_manager.device)
-    if config.use_tt:
-        model = torch.compile(model, backend="tt", options={"tt_enable_torch_fx_fusion_pass": False})
+
     logger.info(f"Loaded {config.model_name} model.")
     logger.info(f"Model parameters: {sum(p.numel() for p in model.parameters())}")
     logger.info(f"Trainable parameters: {sum(p.numel() for p in model.parameters() if p.requires_grad)}")

--- a/blacksmith/experiments/torch/gemma11/test_gemma11_finetuning.py
+++ b/blacksmith/experiments/torch/gemma11/test_gemma11_finetuning.py
@@ -86,8 +86,7 @@ def train(
 
     # Load model
     model = get_model(config, device_manager.device)
-    if config.use_tt:
-        model = torch.compile(model, backend="tt", options={"tt_enable_torch_fx_fusion_pass": False})
+
     logger.info(f"Loaded {config.model_name} model.")
     logger.info(f"Model parameters: {sum(p.numel() for p in model.parameters())}")
     logger.info(f"Trainable parameters: {sum(p.numel() for p in model.parameters() if p.requires_grad)}")

--- a/blacksmith/experiments/torch/llama/xla/test_llama_fine_tuning_pure_torch.py
+++ b/blacksmith/experiments/torch/llama/xla/test_llama_fine_tuning_pure_torch.py
@@ -107,8 +107,7 @@ def train(
 
     # Load model
     model = get_model(config, device_manager.device)
-    if config.use_tt:
-        model = torch.compile(model, backend="tt", options={"tt_enable_torch_fx_fusion_pass": False})
+
     logger.info(f"Loaded {config.model_name} model.")
     logger.info(f"Model parameters: {sum(p.numel() for p in model.parameters())}")
     logger.info(f"Trainable parameters: {sum(p.numel() for p in model.parameters() if p.requires_grad)}")

--- a/blacksmith/experiments/torch/qwen/test_qwen_finetuning.py
+++ b/blacksmith/experiments/torch/qwen/test_qwen_finetuning.py
@@ -93,8 +93,7 @@ def train(
 
     # Load model
     model = get_model(config, device_manager.device)
-    if config.use_tt:
-        model = torch.compile(model, backend="tt", options={"tt_enable_torch_fx_fusion_pass": False})
+
     logger.info(f"Loaded {config.model_name} model.")
     logger.info(f"Model parameters: {sum(p.numel() for p in model.parameters())}")
     logger.info(f"Trainable parameters: {sum(p.numel() for p in model.parameters() if p.requires_grad)}")

--- a/blacksmith/models/torch/huggingface/hf_models.py
+++ b/blacksmith/models/torch/huggingface/hf_models.py
@@ -27,6 +27,10 @@ def get_model(config: TrainingConfig, device: torch.device):
     model.to(eval(config.dtype))
     model.to(device)
 
+    if config.use_tt:
+        compile_options = {"tt_enable_torch_fx_fusion_pass": False, "tt_experimental_compile": False}
+        model = torch.compile(model, backend="tt", options=compile_options)
+
     return model
 
 


### PR DESCRIPTION
### Issue
N/A

### Problem description
New experimental compile that is on by default breaks the backward pass.

### What's Changed
- Unified logic for torch compile
- Disabled experimental compile
