### PR TITLE
Update validation batch handling and cache clearing for llama fine tuning pure torch experiment

### DIFF
--- a/blacksmith/experiments/torch/llama/xla/test_llama_fine_tuning_pure_torch.py
+++ b/blacksmith/experiments/torch/llama/xla/test_llama_fine_tuning_pure_torch.py
@@ -36,15 +36,12 @@ def validate(model, val_data_loader, loss_fn, logger, device, config, tokenizer=
     with torch.no_grad():
         for batch in tqdm(val_data_loader, desc="Validation"):
             batch = device_manager.prepare_batch(batch)
-            input_ids = batch["input_ids"]
-            attention_mask = batch["attention_mask"]
-            expected_output = batch["labels"]
 
             # Shard model if tensor parallelism is used.
             device_manager.shard_model(model)
 
             # Forward pass.
-            outputs = model(input_ids=input_ids, attention_mask=attention_mask)
+            outputs = model(input_ids=batch["input_ids"], attention_mask=batch["attention_mask"])
             logits = outputs.logits
 
             # Shift logits for causal LM: predict next token
@@ -66,11 +63,11 @@ def validate(model, val_data_loader, loss_fn, logger, device, config, tokenizer=
 
             if config.print_examples:
                 collected_examples = collect_examples(
-                    batch_size=expected_output.shape[0],
+                    batch_size=batch["labels"].shape[0],
                     collected_examples=collected_examples,
                     max_examples=10,
-                    input_ids=input_ids,
-                    expected_output=expected_output,
+                    input_ids=batch["input_ids"],
+                    expected_output=batch["labels"],
                     predictions=predictions,
                     num_val_batches=num_val_batches,
                 )


### PR DESCRIPTION
Refactor validation batch preparation and add cache clearing condition.

### Issue
No issue for this bug.

### What's Changed
- Use conditional xr.clear_computational_cache (only if use_tt).
- Use device_manager.prepare_batch instead of manual .to(device) to avoid accidental device mismatches (which occurs on non-TT).

### Checklist
- [x] Bug is reproducible before the fix
- [x] Fix resolves the bug
- [x] Tests pass and updated if needed
- [x] No new bugs introduced
- [x] Documentation updated if needed
