### PR TITLE
Fixing Llama experiment's Out of memory issue by preparing tensors on CPU before transferring back to TT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ logs/
 docs/output
 generated/
 model/
+.vscode/
 
 # Python env
 env/*

--- a/blacksmith/experiments/torch/llama/xla/test_llama_fine_tuning_pure_torch.py
+++ b/blacksmith/experiments/torch/llama/xla/test_llama_fine_tuning_pure_torch.py
@@ -35,13 +35,15 @@ def validate(model, val_data_loader, loss_fn, logger, device, config, tokenizer=
 
     with torch.no_grad():
         for batch in tqdm(val_data_loader, desc="Validation"):
-            batch = device_manager.prepare_batch(batch)
+            input_ids = batch["input_ids"].to(device)
+            attention_mask = batch["attention_mask"].to(device)
+            expected_output = batch["labels"].to(device)
 
             # Shard model if tensor parallelism is used.
             device_manager.shard_model(model)
 
             # Forward pass.
-            outputs = model(input_ids=batch["input_ids"], attention_mask=batch["attention_mask"])
+            outputs = model(input_ids=input_ids, attention_mask=attention_mask)
             logits = outputs.logits
 
             # Shift logits for causal LM: predict next token
@@ -49,7 +51,7 @@ def validate(model, val_data_loader, loss_fn, logger, device, config, tokenizer=
             shift_logits = logits[:, :-1, :].contiguous()
 
             expected_output_one_hot, labels_mask = transform_labels(
-                batch, config.ignored_index, model.model.config.vocab_size
+                expected_output.to("cpu"), config.ignored_index, model.model.config.vocab_size
             )
             loss = loss_fn(shift_logits, expected_output_one_hot, labels_mask)
 
@@ -63,11 +65,11 @@ def validate(model, val_data_loader, loss_fn, logger, device, config, tokenizer=
 
             if config.print_examples:
                 collected_examples = collect_examples(
-                    batch_size=batch["labels"].shape[0],
+                    batch_size=expected_output.shape[0],
                     collected_examples=collected_examples,
                     max_examples=10,
-                    input_ids=batch["input_ids"],
-                    expected_output=batch["labels"],
+                    input_ids=input_ids,
+                    expected_output=expected_output,
                     predictions=predictions,
                     num_val_batches=num_val_batches,
                 )
@@ -141,7 +143,7 @@ def train(
 
                 # TODO: Refactor when https://github.com/tenstorrent/tt-blacksmith/issues/327 is resolved.
                 expected_output, labels_mask = transform_labels(
-                    batch, config.ignored_index, model.model.config.vocab_size
+                    batch["labels"], config.ignored_index, model.model.config.vocab_size
                 )
                 batch = {
                     "input_ids": batch["input_ids"],

--- a/blacksmith/tools/workaround_utils.py
+++ b/blacksmith/tools/workaround_utils.py
@@ -24,8 +24,7 @@ def cross_entropy_loss(shift_logits, expected_output, labels_mask):
 
 
 # Used in conjunction with cross_entropy_loss.
-def transform_labels(batch, ignored_index, vocab_size):
-    labels = batch["labels"]
+def transform_labels(labels, ignored_index, vocab_size):
     labels_mask = labels != ignored_index
     labels[labels == ignored_index] = 0
     expected_output = F.one_hot(labels, num_classes=vocab_size)


### PR DESCRIPTION
### Issue
N/A

### Bug Description
This PR (https://github.com/tenstorrent/tt-blacksmith/pull/445) attempted to solve the problem of device mismatch when multiplying tensors in `loss_fn` on GPU. However, this caused TT runs to break with `Out of memory` errors because of excess DRAM being used.

### What's Changed
This PR reverts some of the changes from the aforementioned PR.
Additionally, this PR returns the `batch["labels"]` to CPU to make `transform_labels` inside validation work only with CPU tensors, therefore assuring pre-preparation is done only on CPU, avoiding memory loss.

> [!NOTE]
> | Device | GPU | TT |
> | ------- | ---- | --- |
> | `device_tensor * cpu_tensor` | ERROR : Devices mismatch | Silently moves `cpu_tensor` to TT |
>
> Previous PR handled the mismatch, but while doing so, it moved the `cpu_tensor` to GPU/TT for good.
> TT clears tensors that have been moved temporarily (like the `cpu_tensor`), but DOESN'T if the tensors are moved tendentiously (`cpu_tensor.to(device)`), leading to an error.

### Environment
- **Commit/Version:** HEAD
- **Hardware:** N300

### Checklist
- [x] Bug is reproducible before the fix
- [x] Fix resolves the bug
- [x] Tests pass and updated if needed
- [x] No new bugs introduced
- [x] Documentation updated if needed
