### PR TITLE
[CI] Add `in-service` tag to avoid picking up faulty runners

### DIFF
--- a/.github/workflows/call-test.yml
+++ b/.github/workflows/call-test.yml
@@ -55,8 +55,6 @@ jobs:
     steps:
 
     - uses: actions/checkout@v4
-      with:
-        lfs: 'true'
 
     - name: Mark repo as safe for git
       run: |

--- a/.github/workflows/call-test.yml
+++ b/.github/workflows/call-test.yml
@@ -37,7 +37,7 @@ jobs:
       matrix:
           build: ${{ fromJson(needs.generate-matrix-test.outputs.test_matrix) }}
 
-    runs-on: ${{ (inputs.use-shared-runners || matrix.build.use-shared-runners) && format('tt-ubuntu-2204-{0}-stable', matrix.build.runs-on) || matrix.build.runs-on }}
+    runs-on: ${{ (inputs.use-shared-runners || matrix.build.use-shared-runners) && format('["tt-ubuntu-2204-{0}-stable", "in-service"]', matrix.build.runs-on) || matrix.build.runs-on }}
 
     name: "test '${{ matrix.build.marks }}' (frontend: ${{ matrix.build.frontend }}, runs-on: ${{ matrix.build.runs-on }})"
 

--- a/.github/workflows/call-test.yml
+++ b/.github/workflows/call-test.yml
@@ -55,6 +55,8 @@ jobs:
     steps:
 
     - uses: actions/checkout@v4
+      with:
+        lfs: 'true'
 
     - name: Mark repo as safe for git
       run: |

--- a/.github/workflows/call-test.yml
+++ b/.github/workflows/call-test.yml
@@ -37,7 +37,7 @@ jobs:
       matrix:
           build: ${{ fromJson(needs.generate-matrix-test.outputs.test_matrix) }}
 
-    runs-on: ${{ (inputs.use-shared-runners || matrix.build.use-shared-runners) && format('["tt-ubuntu-2204-{0}-stable", "in-service"]', matrix.build.runs-on) || matrix.build.runs-on }}
+    runs-on: ${{ (inputs.use-shared-runners || matrix.build.use-shared-runners) && format('tt-ubuntu-2204-{0}-stable', matrix.build.runs-on) || fromJson(format('["{0}", "in-service"]', matrix.build.runs-on)) }}
 
     name: "test '${{ matrix.build.marks }}' (frontend: ${{ matrix.build.frontend }}, runs-on: ${{ matrix.build.runs-on }})"
 


### PR DESCRIPTION
### Issue
N/A

### Problem description
N/A

### What's Changed
Added `in-service` tag like in tt-xla

### Checklist
- [ ] New/Existing tests provide coverage for changes
