### PR TITLE
Add debug wheel download script and debug-aware env activation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ tests/test_logs/
 # Python env
 env/*
 !env/activate
+!env/download_debug_wheel.sh
 !env/ffe_requirements.txt
 !env/xla_requirements.txt
 !env/requirements.txt

--- a/env/activate
+++ b/env/activate
@@ -99,12 +99,18 @@ if [ -d $TT_BLACKSMITH_ENV_DIR/bin ]; then
     # Activate environment
     source $TT_BLACKSMITH_ENV_DIR/bin/activate
 
-    # Check and upgrade packages if needed based on experiment type
-    case $EXPERIMENT_TYPE in
-        1) check_package_version "pjrt-plugin-tt" "env/xla_requirements.txt" ;;
-    esac
+    # Only check tt-xla packages; return early for other experiment types
+    if [ "$EXPERIMENT_TYPE" -ne 1 ]; then
+        return
+    fi
 
-    return
+    # If a debug pjrt-plugin-tt wheel is installed, just tag the prompt
+    if get_installed_version "pjrt-plugin-tt" | grep -q '+dev'; then
+        return
+    fi
+
+    # Otherwise check and upgrade package if needed
+    check_package_version "pjrt-plugin-tt" "env/xla_requirements.txt"
 fi
 
 # Otherwise create it

--- a/env/download_debug_wheel.sh
+++ b/env/download_debug_wheel.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+# Downloads and installs the debug PJRT plugin wheel from GitHub Actions,
+# replacing the currently installed release version of pjrt-plugin-tt.
+
+set -euo pipefail
+
+# Check prerequisites
+command -v pip >/dev/null 2>&1 || { echo "Error: pip is not available. Activate the environment first."; exit 1; }
+command -v gh >/dev/null 2>&1 || { echo "Error: gh CLI is not installed."; exit 1; }
+
+# Step 1: Extract commit hash from pip show output
+SUMMARY=$(pip show pjrt-plugin-tt 2>/dev/null | grep -oP '^Summary: \K.*' || true)
+if [ -z "$SUMMARY" ]; then
+    echo "Error: pjrt-plugin-tt is not installed."
+    exit 1
+fi
+
+COMMIT=$(echo "$SUMMARY" | grep -oP '^commit=\K[0-9a-f]+')
+if [ -z "$COMMIT" ]; then
+    echo "Error: Could not extract commit hash from pjrt-plugin-tt summary."
+    exit 1
+fi
+SHORT_COMMIT=${COMMIT:0:7}
+echo "Found pjrt-plugin-tt commit: $COMMIT ($SHORT_COMMIT)"
+
+# Step 2: Find the GitHub Actions run for this commit
+RUN_ID=$(gh run list \
+    --commit "$COMMIT" \
+    --event push \
+    --limit 1 \
+    --json databaseId \
+    --jq '.[0].databaseId' \
+    -R tenstorrent/tt-xla)
+
+if [ -z "$RUN_ID" ] || [ "$RUN_ID" = "null" ]; then
+    echo "Error: No GitHub Actions run found for commit $COMMIT."
+    exit 1
+fi
+echo "Found GitHub Actions run: $RUN_ID"
+
+# Step 3: Download the debug wheel artifact (skip if already downloaded)
+WHEEL=$(find . -maxdepth 2 -name "pjrt_plugin_tt-*+dev.${SHORT_COMMIT}-*.whl" | head -1)
+if [ -n "$WHEEL" ]; then
+    echo "Wheel already downloaded: $WHEEL"
+else
+    echo "Downloading debug wheel..."
+    gh run download "$RUN_ID" -n "xla-whl-explorer-$SHORT_COMMIT" -R tenstorrent/tt-xla
+    WHEEL=$(find . -maxdepth 2 -name "pjrt_plugin_tt-*+dev.${SHORT_COMMIT}-*.whl" | head -1)
+    if [ -z "$WHEEL" ]; then
+        echo "Error: Could not find downloaded wheel file."
+        exit 1
+    fi
+fi
+echo "Installing debug wheel: $WHEEL"
+pip uninstall -y pjrt-plugin-tt
+pip install "$WHEEL"
+echo "Done. Debug wheel installed."

--- a/env/download_debug_wheel.sh
+++ b/env/download_debug_wheel.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
 # SPDX-License-Identifier: Apache-2.0
 
 # Downloads and installs the debug PJRT plugin wheel from GitHub Actions,

--- a/env/download_debug_wheel.sh
+++ b/env/download_debug_wheel.sh
@@ -4,6 +4,7 @@
 
 # Downloads and installs the debug PJRT plugin wheel from GitHub Actions,
 # replacing the currently installed release version of pjrt-plugin-tt.
+# TODO(ndrakulic): Right now this is workaround, we should have some proper place from where we can pull the debug wheel
 
 set -euo pipefail
 


### PR DESCRIPTION
### Problem description
We want to be able to install wheel with `TT_RUNTIME_DEBUG` enabled, to be able to use `tt-mlir` memory debug info

### What's Changed
- Added `env/download_debug_wheel.sh` script that automates downloading and installing debug `pjrt-plugin-tt` wheels from GitHub Actions. It extracts the commit hash from the currently installed release wheel, finds the matching CI run, downloads the debug artifact, and installs it.
- Updated `env/activate` to detect when a debug wheel (`+dev` version) is installed and skip the version check, so `source env/activate` won't overwrite the debug wheel with the release version.

### Checklist
- [ ] New/Existing tests provide coverage for changes
