### PR TITLE
[AMP] Add LLaMA 3.2 1B BFP8 Experiment

### DIFF
--- a/blacksmith/experiments/torch/llama/configs.py
+++ b/blacksmith/experiments/torch/llama/configs.py
@@ -17,6 +17,10 @@ class TrainingConfig(BaseModel):
     max_length: int = Field(default=128, gt=0)
     dtype: str = Field(default="torch.bfloat16")
 
+    # Mixed precision settings (tt-xla backend only). See tt-xla/docs/src/mixed_precision.md.
+    weight_dtype_overrides: Optional[str] = Field(default=None)  # JSON path (relative to the yaml if not absolute)
+    experimental_weight_dtype: Optional[str] = Field(default=None)  # compiler-level default: "bfp_bf8" | "bfp_bf4" | "bf16"
+
     # Training hyperparameters
     training_type: str = Field(default="lora")  # [lora, adapters]
     learning_rate: float = Field(default=2e-5, gt=0)

--- a/blacksmith/experiments/torch/llama/configs.py
+++ b/blacksmith/experiments/torch/llama/configs.py
@@ -19,7 +19,9 @@ class TrainingConfig(BaseModel):
 
     # Mixed precision settings (tt-xla backend only). See tt-xla/docs/src/mixed_precision.md.
     weight_dtype_overrides: Optional[str] = Field(default=None)  # JSON path (relative to the yaml if not absolute)
-    experimental_weight_dtype: Optional[str] = Field(default=None)  # compiler-level default: "bfp_bf8" | "bfp_bf4" | "bf16"
+    experimental_weight_dtype: Optional[str] = Field(
+        default=None
+    )  # compiler-level default: "bfp_bf8" | "bfp_bf4" | "bf16"
 
     # Training hyperparameters
     training_type: str = Field(default="lora")  # [lora, adapters]

--- a/blacksmith/experiments/torch/llama/xla/lora/single_chip/llama_3_2_1b_bfp8.json
+++ b/blacksmith/experiments/torch/llama/xla/lora/single_chip/llama_3_2_1b_bfp8.json
@@ -1,0 +1,9 @@
+{
+    "*.mlp.gate_proj.weight": "bfp_bf8",
+    "*.mlp.up_proj.weight": "bfp_bf8",
+    "*.mlp.down_proj.weight": "bfp_bf8",
+    "*.self_attn.k_proj.weight": "bfp_bf8",
+    "*.self_attn.o_proj.weight": "bfp_bf8",
+    "*.self_attn.q_proj.base_layer.weight": "bfp_bf8",
+    "*.self_attn.v_proj.base_layer.weight": "bfp_bf8"
+}

--- a/blacksmith/experiments/torch/llama/xla/lora/single_chip/llama_3_2_1b_sst2_bfp8.yaml
+++ b/blacksmith/experiments/torch/llama/xla/lora/single_chip/llama_3_2_1b_sst2_bfp8.yaml
@@ -1,0 +1,63 @@
+# Dataset settings
+dataset_id: "sst2"
+
+# Model settings
+model_name: "meta-llama/Llama-3.2-1B"
+max_length: 64
+dtype: "torch.bfloat16"
+
+# Mixed precision settings
+weight_dtype_overrides: "llama_3_2_1b_bfp8.json"
+# Lowers every matmul weight. Options: "bfp_bf8" | "bfp_bf4" | "bf16".
+experimental_weight_dtype: "bfp_bf8"
+
+# Training hyperparameters
+training_type: "lora"
+learning_rate: 1e-4
+batch_size: 16
+num_epochs: 1
+ignored_index: -100
+
+# LoRA setup
+lora_r: 4
+lora_alpha: 8
+lora_target_modules: ["q_proj", "v_proj"]
+lora_task_type: "CAUSAL_LM"
+
+# Reproducibility settings
+seed: 23
+deterministic: False
+
+# Logging settings
+log_level: "INFO"
+use_wandb: True
+wandb_project: "llama1b-singlechip-lora-bfp8"
+wandb_run_name: "tt-llama1b-bfp8-test"
+wandb_tags: ["test", "bfp8"]
+wandb_watch_mode: "all"
+wandb_log_freq: 1000
+model_to_wandb: False
+steps_freq: 5
+val_steps_freq: 5
+epoch_freq: 1
+
+# Checkpoint settings
+resume_from_checkpoint: False
+resume_option: "last"  # [last, best, path]
+checkpoint_path: "" # path to checkpoint if resume_option is "path"
+checkpoint_metric: "eval/loss"
+checkpoint_metric_mode: "min"  # [min, max]
+keep_last_n: 2
+keep_best_n: 1
+save_strategy: "step"
+project_dir: "blacksmith/experiments/torch/llama/xla/lora"
+save_optim: True
+storage_backend: "local"
+sync_to_storage: False
+load_from_storage: False
+remote_path: ""
+
+# Other settings
+framework: "pytorch"
+print_examples: True
+use_tt: True

--- a/blacksmith/experiments/torch/llama/xla/train.py
+++ b/blacksmith/experiments/torch/llama/xla/train.py
@@ -242,6 +242,13 @@ if __name__ == "__main__":
     args = parse_cli_options(default_config=default_config)
     config: TrainingConfig = generate_config(TrainingConfig, args.config, args.test_config, args.test_checkpoint_path)
 
+    # Resolve a relative weight_dtype_overrides JSON path against the yaml's directory
+    # so configs can live next to the yaml that references them.
+    if isinstance(config.weight_dtype_overrides, str) and config.weight_dtype_overrides.endswith(".json"):
+        override_path = Path(config.weight_dtype_overrides)
+        if not override_path.is_absolute():
+            config.weight_dtype_overrides = str((args.config.parent / override_path).resolve())
+
     # Reproducibility setup
     repro_manager = ReproducibilityManager(config)
     repro_manager.setup()
@@ -257,7 +264,10 @@ if __name__ == "__main__":
     # fp32_dest_acc_en: accumulate partial results in FP32 to avoid precision loss.
     # math_fidelity hifi4: use all 4 mantissa phases for full precision multiplications.
     if config.use_tt:
-        torch_xla.set_custom_compile_options({"fp32_dest_acc_en": True, "math_fidelity": "hifi4"})
+        compile_options = {"fp32_dest_acc_en": True, "math_fidelity": "hifi4"}
+        if config.experimental_weight_dtype:
+            compile_options["experimental_weight_dtype"] = config.experimental_weight_dtype
+        torch_xla.set_custom_compile_options(compile_options)
 
     # Checkpoint manager setup
     checkpoint_manager = CheckpointManager(config, logger, device_manager.device)

--- a/blacksmith/models/torch/huggingface/hf_models.py
+++ b/blacksmith/models/torch/huggingface/hf_models.py
@@ -9,6 +9,28 @@ from transformers import AutoModelForCausalLM
 from blacksmith.tools.templates.configs import TrainingConfig
 
 
+def _is_trainable_param(model: torch.nn.Module, param_path: str) -> bool:
+    """Look up a parameter by its pre-parametrize dotted path and return whether it's trainable.
+
+    After register_parametrization the original lives at
+    `<path-without-.weight>.parametrizations.<weight-name>.original`, so we try
+    that location first and fall back to the original path.
+    """
+    module_path, param_name = param_path.rsplit(".", 1)
+    try:
+        module = model.get_submodule(module_path)
+    except AttributeError:
+        return False
+    param = None
+    if hasattr(module, "parametrizations") and param_name in getattr(
+        module.parametrizations, "_modules", {}
+    ):
+        param = getattr(module.parametrizations[param_name], "original", None)
+    if param is None:
+        param = getattr(module, param_name, None)
+    return isinstance(param, torch.nn.Parameter) and param.requires_grad
+
+
 def get_model(config: TrainingConfig, device: torch.device):
     # This will be replaced with forge models loader, we should add adapter functions to modify the model as needed
 
@@ -26,6 +48,29 @@ def get_model(config: TrainingConfig, device: torch.device):
 
     model.to(eval(config.dtype))
     model.to(device)
+
+    # Per-tensor weight dtype overrides must be registered before torch.compile
+    # so the custom_call appears in the traced graph.
+    overrides = getattr(config, "weight_dtype_overrides", None)
+    if config.use_tt and overrides:
+        from tt_torch import apply_weight_dtype_overrides
+
+        applied = apply_weight_dtype_overrides(model, overrides)
+        print(f"Applied {len(applied)} weight dtype overrides.")
+
+        # register_parametrization does `set_(original, original)` internally,
+        # which freezes XLA storage. If the target is trainable, the optimizer
+        # later fails with "cannot mutate tensors with frozen storage" on the
+        # first in-place update. Fail loudly here with an actionable message.
+        trainable_hits = [name for name, _ in applied if _is_trainable_param(model, name)]
+        if trainable_hits:
+            raise RuntimeError(
+                "weight_dtype_overrides matched trainable parameters, which is "
+                "unsupported during training on XLA (torch parametrize freezes "
+                "their storage and optimizer.step() will fail). Restrict the "
+                "config to frozen weights only.\nOffending parameters:\n  - "
+                + "\n  - ".join(trainable_hits)
+            )
 
     if config.use_tt:
         compile_options = {"tt_enable_torch_fx_fusion_pass": False, "tt_legacy_compile": True}

--- a/blacksmith/models/torch/huggingface/hf_models.py
+++ b/blacksmith/models/torch/huggingface/hf_models.py
@@ -54,7 +54,6 @@ def get_model(config: TrainingConfig, device: torch.device):
         from tt_torch import apply_weight_dtype_overrides
 
         applied = apply_weight_dtype_overrides(model, overrides)
-        print(f"Applied {len(applied)} weight dtype overrides.")
 
         # register_parametrization does `set_(original, original)` internally,
         # which freezes XLA storage. If the target is trainable, the optimizer

--- a/blacksmith/models/torch/huggingface/hf_models.py
+++ b/blacksmith/models/torch/huggingface/hf_models.py
@@ -22,9 +22,7 @@ def _is_trainable_param(model: torch.nn.Module, param_path: str) -> bool:
     except AttributeError:
         return False
     param = None
-    if hasattr(module, "parametrizations") and param_name in getattr(
-        module.parametrizations, "_modules", {}
-    ):
+    if hasattr(module, "parametrizations") and param_name in getattr(module.parametrizations, "_modules", {}):
         param = getattr(module.parametrizations[param_name], "original", None)
     if param is None:
         param = getattr(module, param_name, None)
@@ -68,8 +66,7 @@ def get_model(config: TrainingConfig, device: torch.device):
                 "weight_dtype_overrides matched trainable parameters, which is "
                 "unsupported during training on XLA (torch parametrize freezes "
                 "their storage and optimizer.step() will fail). Restrict the "
-                "config to frozen weights only.\nOffending parameters:\n  - "
-                + "\n  - ".join(trainable_hits)
+                "config to frozen weights only.\nOffending parameters:\n  - " + "\n  - ".join(trainable_hits)
             )
 
     if config.use_tt:

--- a/blacksmith/tools/templates/configs.py
+++ b/blacksmith/tools/templates/configs.py
@@ -17,7 +17,9 @@ class TrainingConfig(BaseModel):
 
     # Mixed precision settings (tt-xla backend only). See tt-xla/docs/src/mixed_precision.md.
     weight_dtype_overrides: Optional[str] = Field(default=None)  # JSON path (relative to the yaml if not absolute)
-    experimental_weight_dtype: Optional[str] = Field(default=None)  # compiler-level default: "bfp_bf8" | "bfp_bf4" | "bf16"
+    experimental_weight_dtype: Optional[str] = Field(
+        default=None
+    )  # compiler-level default: "bfp_bf8" | "bfp_bf4" | "bf16"
 
     # Training hyperparameters
     learning_rate: float = Field(default=2e-5, gt=0)

--- a/blacksmith/tools/templates/configs.py
+++ b/blacksmith/tools/templates/configs.py
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
 #
 # SPDX-License-Identifier: Apache-2.0
+from typing import Optional
+
 from pydantic import BaseModel, Field
 
 
@@ -12,6 +14,10 @@ class TrainingConfig(BaseModel):
     model_name: str = Field(default="path/to/model")
     max_length: int = Field(default=128, gt=0)
     dtype: str = Field(default="torch.bfloat16")
+
+    # Mixed precision settings (tt-xla backend only). See tt-xla/docs/src/mixed_precision.md.
+    weight_dtype_overrides: Optional[str] = Field(default=None)  # JSON path (relative to the yaml if not absolute)
+    experimental_weight_dtype: Optional[str] = Field(default=None)  # compiler-level default: "bfp_bf8" | "bfp_bf4" | "bf16"
 
     # Training hyperparameters
     learning_rate: float = Field(default=2e-5, gt=0)


### PR DESCRIPTION
### Issue
N/A

### Training Workload Setting

- **Model:** LLaMA 3.2 1B
- **Strategy:** LoRA
- **Framework:** PyTorch
- **Task:** Sentiment prediction
- **Dataset:** SST2
- **Hardware:** N150

### What's Changed
This PR showcases training workload for LLaMA 3.2 1B in BFP8.

### Experiment Results


### Swiss Reports
We **reduce DRAM peak by ~16%** and have virually no accuracy drawbacks with this.
Perf remains to be tested, expecting speedups there.

#### BF16
<img width="931" height="662" alt="image" src="https://github.com/user-attachments/assets/25dd4f52-3808-45f6-9bc1-8b77f287e9b0" />

#### BFP8
<img width="933" height="668" alt="image" src="https://github.com/user-attachments/assets/60f846c7-81ec-4e24-ba41-89884c2d8566" />

### W&B Report
<img width="576" height="331" alt="image" src="https://github.com/user-attachments/assets/48ac0256-9611-408a-ad9c-e0d703e1bd97" />


### Checklist
- [ ] Main training workflow
- [ ] CPU testing
- [ ] GPU testing
- [ ] TT device testing
- [ ] CI testing
    - [ ] Existing tests are passing
    - [ ] Register test to CI
    - [ ] Upload golden files if necessary
