### PR TITLE
Add run_decode_example which runs real decode loop during validation instead of showing teacher forcing examples

### DIFF
--- a/blacksmith/experiments/torch/gemma11/configs.py
+++ b/blacksmith/experiments/torch/gemma11/configs.py
@@ -39,6 +39,7 @@ class TrainingConfig(BaseModel):
     epoch_freq: int = Field(default=1)
     val_steps_freq: int = Field(default=50)
     print_examples: bool = Field(default=True)
+    run_decode_example: bool = Field(default=False)
 
     # Checkpoint settings
     resume_from_checkpoint: bool = Field(default=False)

--- a/blacksmith/experiments/torch/gemma11/single_chip/gemma11_sst2.yaml
+++ b/blacksmith/experiments/torch/gemma11/single_chip/gemma11_sst2.yaml
@@ -27,6 +27,7 @@ model_to_wandb: False
 steps_freq: 10
 epoch_freq: 1
 val_steps_freq: 50
+run_decode_example: True
 
 # Checkpoint settings
 resume_from_checkpoint: False

--- a/blacksmith/experiments/torch/gemma11/train.py
+++ b/blacksmith/experiments/torch/gemma11/train.py
@@ -20,8 +20,8 @@ from blacksmith.tools.reproducibility_manager import ReproducibilityManager
 from blacksmith.tools.torch_helpers import (
     collate_fn_for_causal_lm,
     collect_examples,
-    show_examples,
     run_decode_example_from_batch,
+    show_examples,
 )
 
 
@@ -70,7 +70,7 @@ def validate(model, val_data_loader, loss_fn, device_manager, config, logger, to
     if config.print_examples and tokenizer is not None:
         logger.info(f"\n=== Validation Examples (Random samples) ===")
         show_examples(collected_examples, tokenizer, config, logger)
-    
+
     if config.run_decode_example and tokenizer is not None:
         run_decode_example_from_batch(
             model=model,

--- a/blacksmith/experiments/torch/gemma11/train.py
+++ b/blacksmith/experiments/torch/gemma11/train.py
@@ -21,6 +21,7 @@ from blacksmith.tools.torch_helpers import (
     collate_fn_for_causal_lm,
     collect_examples,
     show_examples,
+    run_decode_example_from_batch,
 )
 
 
@@ -69,6 +70,16 @@ def validate(model, val_data_loader, loss_fn, device_manager, config, logger, to
     if config.print_examples and tokenizer is not None:
         logger.info(f"\n=== Validation Examples (Random samples) ===")
         show_examples(collected_examples, tokenizer, config, logger)
+    
+    if config.run_decode_example and tokenizer is not None:
+        run_decode_example_from_batch(
+            model=model,
+            tokenizer=tokenizer,
+            batch=next(iter(val_data_loader)),
+            ignored_index=config.ignored_index,
+            device=device_manager.device,
+            logger=logger,
+        )
 
     avg_val_loss = total_val_loss / num_val_batches if num_val_batches > 0 else 0.0
     logger.info(f"Average validation loss: {avg_val_loss}")

--- a/blacksmith/tools/torch_helpers.py
+++ b/blacksmith/tools/torch_helpers.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 import torch
+from transformers import StaticCache
 
 
 def print_trainable_params(model):
@@ -125,3 +126,143 @@ def collate_fn_for_causal_lm(batch):
     shifted_labels = labels[:, 1:].contiguous()
 
     return {"input_ids": input_ids, "attention_mask": attention_mask, "labels": shifted_labels}
+
+
+# ------------Decode Example From Batch------------
+def run_decode_example_from_batch(
+    model,
+    tokenizer,
+    batch,                           # dict with "input_ids" (B, T) and "labels" (B, T-1)
+    ignored_index: int,
+    device,
+    logger,
+    batch_index: int = 0,
+    **decode_kwargs,
+):
+    """Recover (prompt_ids, target_ids) from a causal-LM batch and run decode.
+
+    Assumes `labels` were pre-shifted by `collate_fn_for_causal_lm` (drops
+    position 0) and that the dataset masked the prompt span with `ignored_index`.
+    Then in the shifted labels the first non-ignored index is (prompt_len - 1),
+    so prompt_end = first_valid + 1 = prompt_len recovers exactly the prompt
+    range in `input_ids`. The non-ignored labels are the (shifted) response
+    token IDs, i.e. the ground-truth completion.
+    """
+    labels_row = batch["labels"][batch_index].to("cpu")
+    input_ids_row = batch["input_ids"][batch_index].to("cpu")
+    valid_mask = labels_row != ignored_index
+    if not valid_mask.any():
+        raise ValueError("All labels are masked; cannot locate prompt boundary for decode example.")
+    prompt_end = valid_mask.int().argmax().item() + 1
+    prompt_ids = input_ids_row[:prompt_end]
+    target_ids = labels_row[valid_mask]
+    run_decode_example(
+        model=model,
+        tokenizer=tokenizer,
+        prompt_ids=prompt_ids,
+        target_ids=target_ids,
+        device=device,
+        logger=logger,
+        **decode_kwargs,
+    )
+
+
+def run_decode_example(
+    model,
+    tokenizer,
+    prompt_ids,                       # 1D LongTensor
+    device,
+    logger,
+    target_ids=None,
+    max_prompt_length: int = 32,
+    max_cache_length: int = 128,
+    max_new_tokens: int = 64,
+):
+    """Run one autoregressive decode on a single prompt."""
+    # Clamp generation length to whatever room the static cache has left after
+    # the prefill window; otherwise cache_position would index past max_cache_len.
+    room_in_cache = max_cache_length - max_prompt_length
+    if room_in_cache < 1:
+        raise ValueError(
+            f"max_prompt_length ({max_prompt_length}) fills the entire cache "
+            f"({max_cache_length}); no room to generate."
+        )
+    max_new_tokens = min(max_new_tokens, room_in_cache)
+
+    logger.info("\n=== Decode Example ===")
+    logger.info(f"Prompt: {tokenizer.decode(prompt_ids, skip_special_tokens=True)!r}")
+    if target_ids is not None:
+        logger.info(f"Target: {tokenizer.decode(target_ids, skip_special_tokens=True)!r}")
+    input_args = construct_inputs_for_decode(
+        prompt_ids=prompt_ids,
+        pad_token_id=tokenizer.pad_token_id,
+        model_config=model.model.config,
+        max_prompt_length=max_prompt_length,
+        max_cache_len=max_cache_length,
+    )
+    # Transfer inputs to device
+    for layer in input_args["past_key_values"].layers:
+        layer.keys = layer.keys.to(device)
+        layer.values = layer.values.to(device)
+    input_args["input_ids"] = input_args["input_ids"].to(device)
+    input_args["cache_position"] = input_args["cache_position"].to(device)
+    input_args["attention_mask"] = input_args["attention_mask"].to(device)
+    # Run generation loop
+    output_tokens = []
+    with torch.no_grad():
+        for step in range(max_new_tokens):
+            if step == 0:
+                logger.info("RUNNING PREFILL")
+            output = model(**input_args)
+            next_token_id = output.logits[:, -1].argmax(dim=-1).to("cpu")    # shape (1,)
+            output_tokens.append(tokenizer.decode(next_token_id))
+            if next_token_id.item() == tokenizer.eos_token_id:
+                break
+            # Advance inputs for next step. 
+            input_args["input_ids"] = next_token_id.unsqueeze(-1).to(device)
+            host_cache_pos = input_args["cache_position"].to("cpu")
+            next_pos = host_cache_pos[-1:] + 1
+            input_args["cache_position"] = next_pos.to(device)
+    logger.info(f"Generated: {''.join(output_tokens)!r}")
+
+
+def construct_inputs_for_decode(
+    prompt_ids,                       # 1D LongTensor, len <= max_prompt_length
+    pad_token_id: int,
+    model_config,
+    max_prompt_length: int,
+    max_cache_len: int,
+):
+    """Build StaticCache inputs from a pre-tokenized prompt (batch size 1)."""
+    prompt_ids = prompt_ids[-max_prompt_length:]                   # left-truncate if needed
+    L = prompt_ids.shape[0]
+    input_ids = torch.full((1, max_prompt_length), pad_token_id, dtype=torch.long)
+    input_ids[0, -L:] = prompt_ids
+    # StaticCache must be built on CPU; transfer happens later.
+    # See https://github.com/tenstorrent/tt-xla/issues/1645
+    static_cache = StaticCache(
+        config=model_config,
+        max_batch_size=1,
+        max_cache_len=max_cache_len,
+        device="cpu",
+        dtype=torch.bfloat16,
+    )
+    head_dim = model_config.hidden_size // model_config.num_attention_heads
+    static_cache.early_initialization(
+        batch_size=1,
+        num_heads=model_config.num_key_value_heads,
+        head_dim=head_dim,
+        dtype=torch.bfloat16,
+        device="cpu",
+    )
+    cache_position = torch.arange(0, max_prompt_length)
+    # Mask is 0 over left-pad slots and 1 elsewhere; sized to max_cache_len.
+    attention_mask = torch.ones((1, max_cache_len), dtype=torch.long)
+    attention_mask[0, : max_prompt_length - L] = 0
+    return {
+        "input_ids": input_ids,
+        "past_key_values": static_cache,
+        "cache_position": cache_position,
+        "use_cache": True,
+        "attention_mask": attention_mask,
+    }

--- a/blacksmith/tools/torch_helpers.py
+++ b/blacksmith/tools/torch_helpers.py
@@ -128,11 +128,10 @@ def collate_fn_for_causal_lm(batch):
     return {"input_ids": input_ids, "attention_mask": attention_mask, "labels": shifted_labels}
 
 
-# ------------Decode Example From Batch------------
 def run_decode_example_from_batch(
     model,
     tokenizer,
-    batch,  # dict with "input_ids" (B, T) and "labels" (B, T-1)
+    batch,
     ignored_index: int,
     device,
     logger,
@@ -170,7 +169,7 @@ def run_decode_example_from_batch(
 def run_decode_example(
     model,
     tokenizer,
-    prompt_ids,  # 1D LongTensor
+    prompt_ids,
     device,
     logger,
     target_ids=None,
@@ -178,7 +177,11 @@ def run_decode_example(
     max_cache_length: int = 128,
     max_new_tokens: int = 64,
 ):
-    """Run one autoregressive decode on a single prompt."""
+    """
+    Run one autoregressive decode on a single prompt.
+    The code is adapted from:
+    https://github.com/tenstorrent/tt-xla/blob/main/examples/pytorch/llama.py
+    """
     # Clamp generation length to whatever room the static cache has left after
     # the prefill window; otherwise cache_position would index past max_cache_len.
     room_in_cache = max_cache_length - max_prompt_length
@@ -200,14 +203,14 @@ def run_decode_example(
         max_prompt_length=max_prompt_length,
         max_cache_len=max_cache_length,
     )
-    # Transfer inputs to device
+    # Transfer inputs to device.
     for layer in input_args["past_key_values"].layers:
         layer.keys = layer.keys.to(device)
         layer.values = layer.values.to(device)
     input_args["input_ids"] = input_args["input_ids"].to(device)
     input_args["cache_position"] = input_args["cache_position"].to(device)
     input_args["attention_mask"] = input_args["attention_mask"].to(device)
-    # Run generation loop
+    # Run generation loop.
     output_tokens = []
     with torch.no_grad():
         for step in range(max_new_tokens):
@@ -234,7 +237,7 @@ def construct_inputs_for_decode(
     max_cache_len: int,
 ):
     """Build StaticCache inputs from a pre-tokenized prompt (batch size 1)."""
-    prompt_ids = prompt_ids[-max_prompt_length:]  # left-truncate if needed
+    prompt_ids = prompt_ids[-max_prompt_length:]
     L = prompt_ids.shape[0]
     input_ids = torch.full((1, max_prompt_length), pad_token_id, dtype=torch.long)
     input_ids[0, -L:] = prompt_ids

--- a/blacksmith/tools/torch_helpers.py
+++ b/blacksmith/tools/torch_helpers.py
@@ -132,7 +132,7 @@ def collate_fn_for_causal_lm(batch):
 def run_decode_example_from_batch(
     model,
     tokenizer,
-    batch,                           # dict with "input_ids" (B, T) and "labels" (B, T-1)
+    batch,  # dict with "input_ids" (B, T) and "labels" (B, T-1)
     ignored_index: int,
     device,
     logger,
@@ -170,7 +170,7 @@ def run_decode_example_from_batch(
 def run_decode_example(
     model,
     tokenizer,
-    prompt_ids,                       # 1D LongTensor
+    prompt_ids,  # 1D LongTensor
     device,
     logger,
     target_ids=None,
@@ -214,11 +214,11 @@ def run_decode_example(
             if step == 0:
                 logger.info("RUNNING PREFILL")
             output = model(**input_args)
-            next_token_id = output.logits[:, -1].argmax(dim=-1).to("cpu")    # shape (1,)
+            next_token_id = output.logits[:, -1].argmax(dim=-1).to("cpu")  # shape (1,)
             output_tokens.append(tokenizer.decode(next_token_id))
             if next_token_id.item() == tokenizer.eos_token_id:
                 break
-            # Advance inputs for next step. 
+            # Advance inputs for next step.
             input_args["input_ids"] = next_token_id.unsqueeze(-1).to(device)
             host_cache_pos = input_args["cache_position"].to("cpu")
             next_pos = host_cache_pos[-1:] + 1
@@ -227,14 +227,14 @@ def run_decode_example(
 
 
 def construct_inputs_for_decode(
-    prompt_ids,                       # 1D LongTensor, len <= max_prompt_length
+    prompt_ids,  # 1D LongTensor, len <= max_prompt_length
     pad_token_id: int,
     model_config,
     max_prompt_length: int,
     max_cache_len: int,
 ):
     """Build StaticCache inputs from a pre-tokenized prompt (batch size 1)."""
-    prompt_ids = prompt_ids[-max_prompt_length:]                   # left-truncate if needed
+    prompt_ids = prompt_ids[-max_prompt_length:]  # left-truncate if needed
     L = prompt_ids.shape[0]
     input_ids = torch.full((1, max_prompt_length), pad_token_id, dtype=torch.long)
     input_ids[0, -L:] = prompt_ids


### PR DESCRIPTION
### Problem Description
Validation loop did not have functionality to run a full decode apart from teacher forcing decode (only predicting next token from the ground truth).

### PR description
This PR adds `run_decode_example` running a decode loop and using static KV cache. The code is adopted from [tt-xla](https://github.com/tenstorrent/tt-xla/blob/main/examples/pytorch/llama.py)

`run_decode_example` is invoked from `run_decode_example_from_batch`, which is extracting prompt and target token ids from the combined items which are passed from the data loader.

Currently, the functionality is only implemented within gemma11.

### Example, tests, and timing
This is how it looks like in the code:
<img width="1443" height="160" alt="image" src="https://github.com/user-attachments/assets/9f5a02b1-7245-4b92-ba38-bf7414a47b3c" />
Since we don't have `EOS` in sst2 template, it didn't stop generating after finishing sentiment info, which is expected.

On first validation, the decode takes ~50sec, but for every following validation it is 5sec or less. 

### Side note
I didn't put any other `torch.compile` in the decode function apart from the initial one for the training (this can be discussed)

