### PR TITLE
Fix CPU/GPU Runs By Adjusting `capturable` Field

### DIFF
--- a/blacksmith/experiments/torch/BOUNTIES/falcon3_1b/train.py
+++ b/blacksmith/experiments/torch/BOUNTIES/falcon3_1b/train.py
@@ -111,7 +111,7 @@ def setup_training(config, device_manager, logger, checkpoint_manager):
     logger.info(f"Loaded {config.dataset_id} dataset. Eval dataset size: {len(eval_dataloader)*config.batch_size}")
 
     trainable_params = [p for p in model.parameters() if p.requires_grad]
-    optimizer = torch.optim.AdamW(trainable_params, capturable=True, lr=config.learning_rate)
+    optimizer = torch.optim.AdamW(trainable_params, capturable=config.use_tt, lr=config.learning_rate)
     loss_fn = torch.nn.CrossEntropyLoss(ignore_index=config.ignored_index)
 
     return (

--- a/blacksmith/experiments/torch/albert/train.py
+++ b/blacksmith/experiments/torch/albert/train.py
@@ -92,7 +92,7 @@ def train(
 
     # Init training components (optimizer, lr scheduler, etc.)
     trainable_params = [p for p in model.parameters() if p.requires_grad]
-    optimizer = torch.optim.AdamW(trainable_params, capturable=True, lr=config.learning_rate)
+    optimizer = torch.optim.AdamW(trainable_params, capturable=config.use_tt, lr=config.learning_rate)
     loss_fn = torch.nn.CrossEntropyLoss()
 
     global_step = 0

--- a/blacksmith/experiments/torch/gemma/train.py
+++ b/blacksmith/experiments/torch/gemma/train.py
@@ -107,7 +107,7 @@ def train(
 
     # Init training components (optimizer, lr scheduler, etc.)
     trainable_params = [p for p in model.parameters() if p.requires_grad]
-    optimizer = torch.optim.AdamW(trainable_params, capturable=True, lr=config.learning_rate)
+    optimizer = torch.optim.AdamW(trainable_params, capturable=config.use_tt, lr=config.learning_rate)
     loss_fn = torch.nn.CrossEntropyLoss(ignore_index=config.ignored_index)
 
     global_step = 0

--- a/blacksmith/experiments/torch/gemma11/train.py
+++ b/blacksmith/experiments/torch/gemma11/train.py
@@ -116,7 +116,7 @@ def train(
 
     # Init training components (optimizer, lr scheduler, etc.)
     trainable_params = [p for p in model.parameters() if p.requires_grad]
-    optimizer = torch.optim.AdamW(trainable_params, capturable=True, lr=config.learning_rate)
+    optimizer = torch.optim.AdamW(trainable_params, capturable=config.use_tt, lr=config.learning_rate)
     loss_fn = torch.nn.CrossEntropyLoss(ignore_index=config.ignored_index)
 
     global_step = 0

--- a/blacksmith/experiments/torch/gpt_oss/train.py
+++ b/blacksmith/experiments/torch/gpt_oss/train.py
@@ -119,7 +119,7 @@ def train(
     logger.info(f"Trainable parameters: {sum(p.numel() for p in model.parameters() if p.requires_grad)}")
 
     trainable_params = [p for p in model.parameters() if p.requires_grad]
-    optimizer = torch.optim.AdamW(trainable_params, capturable=True, lr=config.learning_rate)
+    optimizer = torch.optim.AdamW(trainable_params, capturable=config.use_tt, lr=config.learning_rate)
 
     # Load checkpoint if needed.
     if config.resume_from_checkpoint:

--- a/blacksmith/experiments/torch/llama/xla/train.py
+++ b/blacksmith/experiments/torch/llama/xla/train.py
@@ -117,7 +117,7 @@ def train(
     logger.info(f"Trainable parameters: {sum(p.numel() for p in model.parameters() if p.requires_grad)}")
 
     trainable_params = [p for p in model.parameters() if p.requires_grad]
-    optimizer = torch.optim.AdamW(trainable_params, capturable=True, lr=config.learning_rate)
+    optimizer = torch.optim.AdamW(trainable_params, capturable=config.use_tt, lr=config.learning_rate)
 
     # Load checkpoint if needed.
     if config.resume_from_checkpoint:

--- a/blacksmith/experiments/torch/phi/train.py
+++ b/blacksmith/experiments/torch/phi/train.py
@@ -104,7 +104,7 @@ def train(
 
     # Init training components (optimizer, lr scheduler, etc.)
     trainable_params = [p for p in model.parameters() if p.requires_grad]
-    optimizer = torch.optim.AdamW(trainable_params, capturable=True, lr=config.learning_rate)
+    optimizer = torch.optim.AdamW(trainable_params, capturable=config.use_tt, lr=config.learning_rate)
     loss_fn = torch.nn.CrossEntropyLoss(ignore_index=config.ignored_index)
 
     global_step = 0

--- a/blacksmith/experiments/torch/qwen/train.py
+++ b/blacksmith/experiments/torch/qwen/train.py
@@ -100,7 +100,7 @@ def train(
     logger.info(f"Trainable parameters: {sum(p.numel() for p in model.parameters() if p.requires_grad)}")
 
     trainable_params = [p for p in model.parameters() if p.requires_grad]
-    optimizer = torch.optim.AdamW(trainable_params, capturable=True, lr=config.learning_rate)
+    optimizer = torch.optim.AdamW(trainable_params, capturable=config.use_tt, lr=config.learning_rate)
 
     loss_fn = torch.nn.CrossEntropyLoss(ignore_index=config.ignored_index)
 

--- a/blacksmith/experiments/torch/vit/train.py
+++ b/blacksmith/experiments/torch/vit/train.py
@@ -104,7 +104,7 @@ def train(
 
     # Initialize the optimizer.
     trainable_params = [p for p in model.parameters() if p.requires_grad]
-    optimizer = torch.optim.AdamW(trainable_params, capturable=True, lr=config.learning_rate)
+    optimizer = torch.optim.AdamW(trainable_params, capturable=config.use_tt, lr=config.learning_rate)
     loss_fn = eval(config.loss_fn)(ignore_index=config.ignored_index)
 
     # Load the checkpoint if needed.


### PR DESCRIPTION
### Issue
N/A

### Bug Description
The add of `capturable` in https://github.com/tenstorrent/tt-blacksmith/pull/525 did not run CPU/GPU experiments that rely on not using torch_xla. When `capturable` is true we cannot even run CPU experiments.

###  Steps to Reproduce
Run any single-chip experiment with `config.use_tt` set to `False`.

### What's Changed
Change in optimizer that `capturable` field is set to `config.use_tt`.

### Checklist
- [x] Bug is reproducible before the fix
- [x] Fix resolves the bug
