### PR TITLE
Add option to pass tt-xla run id instead for debug wheel download

### DIFF
--- a/env/download_debug_wheel.sh
+++ b/env/download_debug_wheel.sh
@@ -8,39 +8,57 @@
 
 set -euo pipefail
 
+# Optional argument: GitHub Actions run ID to download the wheel from.
+# If not provided, the run ID is resolved from the installed pjrt-plugin-tt commit.
+RUN_ID_ARG="${1:-}"
+
 # Check prerequisites
 command -v pip >/dev/null 2>&1 || { echo "Error: pip is not available. Activate the environment first."; exit 1; }
 command -v gh >/dev/null 2>&1 || { echo "Error: gh CLI is not installed."; exit 1; }
 
-# Step 1: Extract commit hash from pip show output
-SUMMARY=$(pip show pjrt-plugin-tt 2>/dev/null | grep -oP '^Summary: \K.*' || true)
-if [ -z "$SUMMARY" ]; then
-    echo "Error: pjrt-plugin-tt is not installed."
-    exit 1
-fi
+if [ -n "$RUN_ID_ARG" ]; then
+    RUN_ID="$RUN_ID_ARG"
+    echo "Using provided GitHub Actions run: $RUN_ID"
 
-COMMIT=$(echo "$SUMMARY" | grep -oP '^commit=\K[0-9a-f]+')
-if [ -z "$COMMIT" ]; then
-    echo "Error: Could not extract commit hash from pjrt-plugin-tt summary."
-    exit 1
-fi
-SHORT_COMMIT=${COMMIT:0:7}
-echo "Found pjrt-plugin-tt commit: $COMMIT ($SHORT_COMMIT)"
+    # Resolve the commit hash from the run so we know which wheel filename to look for.
+    COMMIT=$(gh run view "$RUN_ID" --json headSha --jq '.headSha' -R tenstorrent/tt-xla)
+    if [ -z "$COMMIT" ] || [ "$COMMIT" = "null" ]; then
+        echo "Error: Could not resolve commit for run $RUN_ID."
+        exit 1
+    fi
+    SHORT_COMMIT=${COMMIT:0:7}
+    echo "Run $RUN_ID is for commit: $COMMIT ($SHORT_COMMIT)"
+else
+    # Step 1: Extract commit hash from pip show output
+    SUMMARY=$(pip show pjrt-plugin-tt 2>/dev/null | grep -oP '^Summary: \K.*' || true)
+    if [ -z "$SUMMARY" ]; then
+        echo "Error: pjrt-plugin-tt is not installed."
+        exit 1
+    fi
 
-# Step 2: Find the GitHub Actions run for this commit
-RUN_ID=$(gh run list \
-    --commit "$COMMIT" \
-    --event push \
-    --limit 1 \
-    --json databaseId \
-    --jq '.[0].databaseId' \
-    -R tenstorrent/tt-xla)
+    COMMIT=$(echo "$SUMMARY" | grep -oP '^commit=\K[0-9a-f]+')
+    if [ -z "$COMMIT" ]; then
+        echo "Error: Could not extract commit hash from pjrt-plugin-tt summary."
+        exit 1
+    fi
+    SHORT_COMMIT=${COMMIT:0:7}
+    echo "Found pjrt-plugin-tt commit: $COMMIT ($SHORT_COMMIT)"
 
-if [ -z "$RUN_ID" ] || [ "$RUN_ID" = "null" ]; then
-    echo "Error: No GitHub Actions run found for commit $COMMIT."
-    exit 1
+    # Step 2: Find the GitHub Actions run for this commit
+    RUN_ID=$(gh run list \
+        --commit "$COMMIT" \
+        --event push \
+        --limit 1 \
+        --json databaseId \
+        --jq '.[0].databaseId' \
+        -R tenstorrent/tt-xla)
+
+    if [ -z "$RUN_ID" ] || [ "$RUN_ID" = "null" ]; then
+        echo "Error: No GitHub Actions run found for commit $COMMIT."
+        exit 1
+    fi
+    echo "Found GitHub Actions run: $RUN_ID"
 fi
-echo "Found GitHub Actions run: $RUN_ID"
 
 # Step 3: Download the debug wheel artifact (skip if already downloaded)
 WHEEL=$(find . -maxdepth 2 -name "pjrt_plugin_tt-*+dev.${SHORT_COMMIT}-*.whl" | head -1)


### PR DESCRIPTION
### Issue
N/A

### Problem description
Enable downloading custom wheel from provided run id

### What's Changed
Added optional argument and if to short-circuit the logic for finding the run ID to the `env/download_debug_wheel.sh`

### Checklist
- [ ] New/Existing tests provide coverage for changes
