### PR TITLE
[CI] Set Gemma 1.1 as XFAIL

### DIFF
--- a/tests/training_test_cases.py
+++ b/tests/training_test_cases.py
@@ -313,7 +313,7 @@ TRAINING_TEST_CASES = [
             "timeout": 10000,
         },
         marks=[
-            pytest.mark.skip(reason="PCC issues, currently investigating."),
+            pytest.mark.xfail(reason="PCC issues, currently investigating.", strict=False),
             pytest.mark.uplift,
             pytest.mark.n150,
             pytest.mark.torch,

--- a/tests/training_test_cases.py
+++ b/tests/training_test_cases.py
@@ -313,6 +313,7 @@ TRAINING_TEST_CASES = [
             "timeout": 10000,
         },
         marks=[
+            pytest.mark.skip(reason="PCC issues, currently investigating."),
             pytest.mark.uplift,
             pytest.mark.n150,
             pytest.mark.torch,


### PR DESCRIPTION
We are currently investigating PCC issues that appear in Gemma 1.1 training, setting test as XFAIL to unblock further uplifts until issue is solved.
