### PR TITLE
Fix Determinism In Reproducibility Manager

### DIFF
--- a/blacksmith/tools/reproducibility_manager.py
+++ b/blacksmith/tools/reproducibility_manager.py
@@ -21,9 +21,9 @@ class ReproducibilityManager:
     def setup(self):
         self._setup_python()
 
-        if self.config.framework == Framework.PYTORCH:
+        if self.config.framework == Framework.PYTORCH.value:
             self._setup_pytorch()
-        elif self.config.framework == Framework.JAX or self.config.framework == Framework.EASYDEL:
+        elif self.config.framework == Framework.JAX.value or self.config.framework == Framework.EASYDEL.value:
             self._setup_jax()
         else:
             logger.warning(f"Unknown framework: {self.config.framework}")

--- a/blacksmith/tools/templates/configs.py
+++ b/blacksmith/tools/templates/configs.py
@@ -73,5 +73,5 @@ class TrainingConfig(BaseModel):
     unfreeze_embeddings: bool = Field(default=False)
 
     # Other settings
-    framework: Framework = Field(default=Framework.PYTORCH)
+    framework: Framework = Field(default=Framework.PYTORCH.value)
     use_tt: bool = Field(default=True)


### PR DESCRIPTION
### Issue
N/A

### Bug Description
In refactor we forgot to add `.value` on fields so runs were not matching proper framework.

### What's Changed
Fixed matching patterns to call `.value` on enums and properly apply determinism in `reproducibility_manager`

### Checklist
- [x] Run single run two times.
