### PR TITLE
Fix Logging In Torch Experiments When Gradient Accumulation Is On

### DIFF
--- a/blacksmith/experiments/torch/gpt_oss/train.py
+++ b/blacksmith/experiments/torch/gpt_oss/train.py
@@ -140,7 +140,6 @@ def train(
     GRAD_CLIP_MAX_NORM = 1.0
 
     global_step = 0
-    running_loss = 0.0
 
     try:
         # Initial validation
@@ -160,6 +159,7 @@ def train(
 
         for epoch in range(config.num_epochs):
             accumulation_step = 0
+            running_loss = 0.0
 
             for batch in tqdm(train_dataloader, desc="Training"):
                 # Zero out gradients at the start of accumulation cycle

--- a/blacksmith/experiments/torch/llama/xla/train.py
+++ b/blacksmith/experiments/torch/llama/xla/train.py
@@ -135,7 +135,6 @@ def train(
     tokenizer = train_dataset.tokenizer
 
     global_step = 0
-    running_loss = 0.0
 
     try:
         # Initial validation
@@ -154,6 +153,7 @@ def train(
 
         for epoch in range(config.num_epochs):
             accumulation_step = 0
+            running_loss = 0.0
 
             for batch in tqdm(train_dataloader, desc="Training"):
                 # Zero out gradients at the start of accumulation cycle


### PR DESCRIPTION
### Issue
N/A

### Bug Description
Currently in code, if number of batches in single epoch is not divisible by `gradient_accumulation_step` we just start the counter from 0 once the epoch ends. This is incorrect for logging, as `running_loss` is only reset once we enter logging phase, so we will have wrong starting point. 

### What's Changed
Move reinitialization of `running_loss` to epoch start.

### Checklist
- [x] Run experiment to confirm compilation
