### PR TITLE
[PERF] Join FWD + BWD and Sync Tensors Precisely

### DIFF
--- a/blacksmith/experiments/torch/llama/xla/lora/single_chip/llama_3_1_8b_sst2.yaml
+++ b/blacksmith/experiments/torch/llama/xla/lora/single_chip/llama_3_1_8b_sst2.yaml
@@ -3,13 +3,13 @@ dataset_id: "sst2"
 
 # Model settings
 model_name: "meta-llama/Llama-3.1-8B"
-max_length: 512
+max_length: 128
 dtype: "torch.bfloat16"
 
 # Training hyperparameters
 training_type: "lora"
 learning_rate: 1e-4
-batch_size: 1
+batch_size: 8
 num_epochs: 1
 ignored_index: -100
 
@@ -56,4 +56,4 @@ remote_path: ""
 framework: "pytorch"
 print_examples: True
 use_tt: True
-measure_e2e_time: True
+measure_e2e_time: False

--- a/blacksmith/experiments/torch/llama/xla/lora/single_chip/llama_3_1_8b_sst2.yaml
+++ b/blacksmith/experiments/torch/llama/xla/lora/single_chip/llama_3_1_8b_sst2.yaml
@@ -3,13 +3,13 @@ dataset_id: "sst2"
 
 # Model settings
 model_name: "meta-llama/Llama-3.1-8B"
-max_length: 128
+max_length: 512
 dtype: "torch.bfloat16"
 
 # Training hyperparameters
 training_type: "lora"
 learning_rate: 1e-4
-batch_size: 8
+batch_size: 1
 num_epochs: 1
 ignored_index: -100
 
@@ -56,4 +56,4 @@ remote_path: ""
 framework: "pytorch"
 print_examples: True
 use_tt: True
-measure_e2e_time: False
+measure_e2e_time: True

--- a/blacksmith/experiments/torch/llama/xla/train.py
+++ b/blacksmith/experiments/torch/llama/xla/train.py
@@ -92,7 +92,6 @@ def compute_loss(batch, model, loss_fn, gradient_accumulation_steps):
     logits = output.logits
     shift_logits = logits[:, :-1, :].contiguous()
     loss = loss_fn(shift_logits, batch["expected_output"], batch["labels_mask"])
-    # Scale by the accumulation steps so the effective-batch gradient is the mean.
     return loss / gradient_accumulation_steps
 
 
@@ -215,8 +214,6 @@ def train(
                         logger.info(f"Step {global_step} e2e time: {step_elapsed:.3f}s")
 
                     if global_step % config.steps_freq == 0:
-                        # loss_ is already scaled by gradient_accumulation_steps, so running_loss
-                        # holds the summed per-step mean loss; divide by steps_freq for the window mean.
                         avg_loss = running_loss / config.steps_freq
                         logger.log_metrics({"train/loss": avg_loss}, commit=False, step=global_step)
                         running_loss = 0.0

--- a/blacksmith/experiments/torch/llama/xla/train.py
+++ b/blacksmith/experiments/torch/llama/xla/train.py
@@ -87,14 +87,11 @@ def validate(model, val_data_loader, loss_fn, logger, device, config, tokenizer=
     return avg_val_loss
 
 
-def training_step_inner(batch, model, loss_fn, gradient_accumulation_steps):
+def compute_loss(batch, model, loss_fn):
     output = model(input_ids=batch["input_ids"], attention_mask=batch["attention_mask"])
     logits = output.logits
     shift_logits = logits[:, :-1, :].contiguous()
-    loss = loss_fn(shift_logits, batch["expected_output"], batch["labels_mask"])
-    # Scale loss by number of accumulation steps to get correct effective batch size.
-    scaled_loss = loss / gradient_accumulation_steps
-    return scaled_loss
+    return loss_fn(shift_logits, batch["expected_output"], batch["labels_mask"])
 
 
 def train(
@@ -130,9 +127,17 @@ def train(
 
     tokenizer = train_dataset.tokenizer
 
-    compile_options = {"tt_enable_torch_fx_fusion_pass": False, "tt_legacy_compile": True, "tt_lazy_execution": True}
-    train_fn = torch.compile(training_step_inner, backend="tt", options=compile_options)
-    model_compiled = torch.compile(model, backend="tt", options=compile_options)
+    if config.use_tt:
+        compile_options = {
+            "tt_enable_torch_fx_fusion_pass": False,
+            "tt_legacy_compile": True,
+            "tt_lazy_execution": True,
+        }
+        compute_loss_fn = torch.compile(compute_loss, backend="tt", options=compile_options)
+        eval_model = torch.compile(model, backend="tt", options=compile_options)
+    else:
+        compute_loss_fn = compute_loss
+        eval_model = model
 
     global_step = 0
 
@@ -140,7 +145,7 @@ def train(
         # Initial validation
         model.eval()
         val_loss = validate(
-            model_compiled,
+            eval_model,
             eval_dataloader,
             cross_entropy_loss,
             logger,
@@ -183,15 +188,17 @@ def train(
                 # Shard model if tensor parallelism is used.
                 device_manager.shard_model(model)
 
-                # Forward (compiled) + backward (traced lazily into the same graph).
-                loss_ = train_fn(batch, model, cross_entropy_loss, config.gradient_accumulation_steps)
-                loss_.backward()
+                loss_ = compute_loss_fn(batch, model, cross_entropy_loss)
+                # Scale by the accumulation steps so the effective-batch gradient is the mean.
+                scaled_loss = loss_ / config.gradient_accumulation_steps
+                scaled_loss.backward()
 
-                # Sync only gradients and loss.
-                tensors_to_sync = [loss_] + [p.grad for p in trainable_params if p.grad is not None]
-                devices = list({t.device.type for t in tensors_to_sync})
-                torch_xla._XLAC._xla_sync_multi(tensors_to_sync, devices, wait=True)
-                torch_xla._XLAC._clear_pending_irs(torch_xla._XLAC._xla_get_default_device())
+                if config.use_tt:
+                    tensors_to_sync = [loss_] + [p.grad for p in trainable_params if p.grad is not None]
+                    devices = list({t.device.type for t in tensors_to_sync})
+                    torch_xla._XLAC._xla_sync_multi(tensors_to_sync, devices, wait=True)
+                    # Optimizer will do unnecessary recompute if we don't clear the pending IRs after syncing the loss and grads.
+                    torch_xla._XLAC._clear_pending_irs(torch_xla._XLAC._xla_get_default_device())
 
                 running_loss += loss_.item()
                 accumulation_step += 1
@@ -216,7 +223,7 @@ def train(
                     if global_step % config.val_steps_freq == 0:
                         model.eval()
                         val_loss = validate(
-                            model_compiled,
+                            eval_model,
                             eval_dataloader,
                             cross_entropy_loss,
                             logger,

--- a/blacksmith/experiments/torch/llama/xla/train.py
+++ b/blacksmith/experiments/torch/llama/xla/train.py
@@ -87,11 +87,6 @@ def validate(model, val_data_loader, loss_fn, logger, device, config, tokenizer=
     return avg_val_loss
 
 
-# Training step extracted into a separate function to keep large vocab-sized
-# tensors (e.g. logits) scoped locally. This ensures they do not propagate beyond
-# the step via the computation graph, avoiding unnecessary and expensive
-# CCLs in multi-chip setups.
-# Issue itself should be investigated further.
 def training_step_inner(batch, model, loss_fn, gradient_accumulation_steps):
     output = model(input_ids=batch["input_ids"], attention_mask=batch["attention_mask"])
     logits = output.logits
@@ -99,8 +94,7 @@ def training_step_inner(batch, model, loss_fn, gradient_accumulation_steps):
     loss = loss_fn(shift_logits, batch["expected_output"], batch["labels_mask"])
     # Scale loss by number of accumulation steps to get correct effective batch size.
     scaled_loss = loss / gradient_accumulation_steps
-    scaled_loss.backward()
-    return loss.detach()
+    return scaled_loss
 
 
 def train(
@@ -112,7 +106,7 @@ def train(
     logger.info("Starting training...")
 
     # Load model.
-    model = get_model(config, device_manager.device)
+    model = get_model(config, device_manager.device, compile_model=False)
     logger.info(f"Loaded {config.model_name} model.")
     logger.info(f"Model parameters: {sum(p.numel() for p in model.parameters())}")
     logger.info(f"Trainable parameters: {sum(p.numel() for p in model.parameters() if p.requires_grad)}")
@@ -134,6 +128,9 @@ def train(
     logger.info(f"Loaded {config.dataset_id} dataset. Eval dataset size: {len(eval_dataloader)*config.batch_size}")
 
     tokenizer = train_dataset.tokenizer
+
+    compile_options = {"tt_enable_torch_fx_fusion_pass": False, "tt_legacy_compile": True, "tt_lazy_execution": True}
+    train_fn = torch.compile(training_step_inner, backend="tt", options=compile_options)
 
     global_step = 0
 
@@ -184,11 +181,15 @@ def train(
                 # Shard model if tensor parallelism is used.
                 device_manager.shard_model(model)
 
-                # Training step.
-                loss_ = training_step_inner(batch, model, cross_entropy_loss, config.gradient_accumulation_steps)
+                # Forward (compiled) + backward (traced lazily into the same graph).
+                loss_ = train_fn(batch, model, cross_entropy_loss, config.gradient_accumulation_steps)
+                loss_.backward()
 
-                if config.use_tt:
-                    torch_xla.sync(wait=True)
+                # Sync only gradients and loss.
+                tensors_to_sync = [loss_] + [p.grad for p in trainable_params if p.grad is not None]
+                devices = list({t.device.type for t in  tensors_to_sync})
+                torch_xla._XLAC._xla_sync_multi(tensors_to_sync, devices, wait=True) 
+                torch_xla._XLAC._clear_pending_irs(torch_xla._XLAC._xla_get_default_device())
 
                 running_loss += loss_.item()
                 accumulation_step += 1

--- a/blacksmith/experiments/torch/llama/xla/train.py
+++ b/blacksmith/experiments/torch/llama/xla/train.py
@@ -87,11 +87,13 @@ def validate(model, val_data_loader, loss_fn, logger, device, config, tokenizer=
     return avg_val_loss
 
 
-def compute_loss(batch, model, loss_fn):
+def compute_loss(batch, model, loss_fn, gradient_accumulation_steps):
     output = model(input_ids=batch["input_ids"], attention_mask=batch["attention_mask"])
     logits = output.logits
     shift_logits = logits[:, :-1, :].contiguous()
-    return loss_fn(shift_logits, batch["expected_output"], batch["labels_mask"])
+    loss = loss_fn(shift_logits, batch["expected_output"], batch["labels_mask"])
+    # Scale by the accumulation steps so the effective-batch gradient is the mean.
+    return loss / gradient_accumulation_steps
 
 
 def train(
@@ -188,10 +190,8 @@ def train(
                 # Shard model if tensor parallelism is used.
                 device_manager.shard_model(model)
 
-                loss_ = compute_loss_fn(batch, model, cross_entropy_loss)
-                # Scale by the accumulation steps so the effective-batch gradient is the mean.
-                scaled_loss = loss_ / config.gradient_accumulation_steps
-                scaled_loss.backward()
+                loss_ = compute_loss_fn(batch, model, cross_entropy_loss, config.gradient_accumulation_steps)
+                loss_.backward()
 
                 if config.use_tt:
                     tensors_to_sync = [loss_] + [p.grad for p in trainable_params if p.grad is not None]
@@ -215,7 +215,9 @@ def train(
                         logger.info(f"Step {global_step} e2e time: {step_elapsed:.3f}s")
 
                     if global_step % config.steps_freq == 0:
-                        avg_loss = running_loss / (config.steps_freq * config.gradient_accumulation_steps)
+                        # loss_ is already scaled by gradient_accumulation_steps, so running_loss
+                        # holds the summed per-step mean loss; divide by steps_freq for the window mean.
+                        avg_loss = running_loss / config.steps_freq
                         logger.log_metrics({"train/loss": avg_loss}, commit=False, step=global_step)
                         running_loss = 0.0
 

--- a/blacksmith/experiments/torch/llama/xla/train.py
+++ b/blacksmith/experiments/torch/llama/xla/train.py
@@ -189,8 +189,8 @@ def train(
 
                 # Sync only gradients and loss.
                 tensors_to_sync = [loss_] + [p.grad for p in trainable_params if p.grad is not None]
-                devices = list({t.device.type for t in  tensors_to_sync})
-                torch_xla._XLAC._xla_sync_multi(tensors_to_sync, devices, wait=True) 
+                devices = list({t.device.type for t in tensors_to_sync})
+                torch_xla._XLAC._xla_sync_multi(tensors_to_sync, devices, wait=True)
                 torch_xla._XLAC._clear_pending_irs(torch_xla._XLAC._xla_get_default_device())
 
                 running_loss += loss_.item()

--- a/blacksmith/experiments/torch/llama/xla/train.py
+++ b/blacksmith/experiments/torch/llama/xla/train.py
@@ -107,6 +107,7 @@ def train(
 
     # Load model.
     model = get_model(config, device_manager.device, compile_model=False)
+
     logger.info(f"Loaded {config.model_name} model.")
     logger.info(f"Model parameters: {sum(p.numel() for p in model.parameters())}")
     logger.info(f"Trainable parameters: {sum(p.numel() for p in model.parameters() if p.requires_grad)}")
@@ -131,6 +132,7 @@ def train(
 
     compile_options = {"tt_enable_torch_fx_fusion_pass": False, "tt_legacy_compile": True, "tt_lazy_execution": True}
     train_fn = torch.compile(training_step_inner, backend="tt", options=compile_options)
+    model_compiled = torch.compile(model, backend="tt", options=compile_options)
 
     global_step = 0
 
@@ -138,7 +140,7 @@ def train(
         # Initial validation
         model.eval()
         val_loss = validate(
-            model,
+            model_compiled,
             eval_dataloader,
             cross_entropy_loss,
             logger,
@@ -214,7 +216,7 @@ def train(
                     if global_step % config.val_steps_freq == 0:
                         model.eval()
                         val_loss = validate(
-                            model,
+                            model_compiled,
                             eval_dataloader,
                             cross_entropy_loss,
                             logger,

--- a/blacksmith/models/torch/huggingface/hf_models.py
+++ b/blacksmith/models/torch/huggingface/hf_models.py
@@ -29,7 +29,7 @@ def _is_trainable_param(model: torch.nn.Module, param_path: str) -> bool:
     return isinstance(param, torch.nn.Parameter) and param.requires_grad
 
 
-def get_model(config: TrainingConfig, device: torch.device):
+def get_model(config: TrainingConfig, device: torch.device, compile_model: bool = True):
     # This will be replaced with forge models loader, we should add adapter functions to modify the model as needed
 
     # Load a model
@@ -68,7 +68,7 @@ def get_model(config: TrainingConfig, device: torch.device):
                 "config to frozen weights only.\nOffending parameters:\n  - " + "\n  - ".join(trainable_hits)
             )
 
-    if config.use_tt:
+    if config.use_tt and compile_model:
         compile_options = {"tt_enable_torch_fx_fusion_pass": False, "tt_legacy_compile": True}
         model = torch.compile(model, backend="tt", options=compile_options)
 


### PR DESCRIPTION
### Issue
N/A

---

### Problem description

By default, tt-torch backend inside tt-xla does some variant of `torch_xla.sync()` [call during model execution](https://github.com/tenstorrent/tt-xla/blob/a0ba4ca3266475f441f3d326d612d5659c5845ae/python_package/tt_torch/backend/backend.py#L272). 
[Recent PR](https://github.com/tenstorrent/tt-xla/pull/5235) on the tt-xla repo allows for purely lazy execution. 

This allows us to lazily join FWD & BWD graphs and to be surgical about which tensors we should sync. 

This yields performance improvements since we avoid redundant computation.

---

### Perf Improvement noticed on Mixa's QB2:

**LLaMA 3.1 8B, BS=1 SEQ=512**

| Old | New | Improvement |
| --- | --- | --- |
5.13s | 3.74s | 27.2%

**LLaMA 70B L=40, BS=1 SEQ=512**
| Old | New | Improvement |
| --- | --- | --- |
2.156s | 1.858s | 13.82%

Training curve and loss values don't seem to change.

---

### Notes:

- Noticed a memory regression described [here](https://github.com/tenstorrent/tt-blacksmith/issues/625).
- The LLaMA 70B numbers look a bit suspicious. Will look into during trace effort. https://github.com/tenstorrent/tt-blacksmith/issues/626
- AOT Autograd will require more work on this since by default it joins them which is undesirable since tensors remain persistent. There are a few ways to tackle this, currently prototyping. 

---

### What's Changed
- Change LLaMA script to include performance improved calls.
- Make model compilation configurable.

### Checklist
- [ ] New/Existing tests provide coverage for changes
