### PR TITLE
GPU Setup and Model Loading Fixes

### DIFF
--- a/blacksmith/datasets/torch/dataset_utils.py
+++ b/blacksmith/datasets/torch/dataset_utils.py
@@ -8,7 +8,6 @@ from blacksmith.datasets.torch.banking77.banking77_dataset import Banking77Datas
 from blacksmith.datasets.torch.BOUNTIES.wikitext.wikitext_dataset import WikitextDataset
 from blacksmith.datasets.torch.metamathqa.metamathqa_dataset import MetaMathQADataset
 from blacksmith.datasets.torch.mnist.mnist_dataset import MNISTDataset
-from blacksmith.datasets.torch.nerf.blender import BlenderDataset
 from blacksmith.datasets.torch.squadV2.squadV2_dataset import SquadV2Dataset
 from blacksmith.datasets.torch.sst2.sst2_dataset import SSTDataset
 from blacksmith.datasets.torch.stanfordcars.stanfordcars_dataset import (
@@ -38,6 +37,8 @@ def get_dataset(config: TrainingConfig, split: str = "train", collate_fn=None):
     if dataset_id == AvailableDataset.MNIST.value:
         return MNISTDataset(config, split, collate_fn=collate_fn)
     elif dataset_id == AvailableDataset.NERF.value:
+        from blacksmith.datasets.torch.nerf.blender import BlenderDataset
+
         return BlenderDataset(config, split, collate_fn=collate_fn)
     elif dataset_id == AvailableDataset.SST2.value:
         return SSTDataset(config, split, collate_fn=collate_fn)

--- a/blacksmith/datasets/torch/dataset_utils.py
+++ b/blacksmith/datasets/torch/dataset_utils.py
@@ -37,6 +37,7 @@ def get_dataset(config: TrainingConfig, split: str = "train", collate_fn=None):
     if dataset_id == AvailableDataset.MNIST.value:
         return MNISTDataset(config, split, collate_fn=collate_fn)
     elif dataset_id == AvailableDataset.NERF.value:
+        # BlenderDataset requires kornia, which has problems with torch 2.7.0 version.
         from blacksmith.datasets.torch.nerf.blender import BlenderDataset
 
         return BlenderDataset(config, split, collate_fn=collate_fn)

--- a/blacksmith/models/torch/huggingface/hf_models.py
+++ b/blacksmith/models/torch/huggingface/hf_models.py
@@ -33,7 +33,16 @@ def get_model(config: TrainingConfig, device: torch.device):
     # This will be replaced with forge models loader, we should add adapter functions to modify the model as needed
 
     # Load a model
-    model = AutoModelForCausalLM.from_pretrained(config.model_name, use_cache=config.gradient_checkpointing)
+    load_on_gpu = not config.use_tt and device.type == "cuda"
+    load_kwargs = {
+        "use_cache": config.gradient_checkpointing,
+        "low_cpu_mem_usage": True,
+    }
+    if load_on_gpu:
+        # Stream weights directly to GPU to avoid CPU RAM spikes during load.
+        load_kwargs["device_map"] = device
+
+    model = AutoModelForCausalLM.from_pretrained(config.model_name, **load_kwargs)
 
     # Apply training specific modifications
     # Apply LoRA if rank is specified
@@ -45,7 +54,8 @@ def get_model(config: TrainingConfig, device: torch.device):
         raise ValueError(f"Invalid training type: {config.training_type}")
 
     model.to(eval(config.dtype))
-    model.to(device)
+    if not load_on_gpu:
+        model.to(device)
 
     # Per-tensor weight dtype overrides must be registered before torch.compile
     # so the custom_call appears in the traced graph.

--- a/blacksmith/models/torch/huggingface/hf_models.py
+++ b/blacksmith/models/torch/huggingface/hf_models.py
@@ -33,12 +33,11 @@ def get_model(config: TrainingConfig, device: torch.device):
     # This will be replaced with forge models loader, we should add adapter functions to modify the model as needed
 
     # Load a model
-    load_on_gpu = not config.use_tt and device.type == "cuda"
     load_kwargs = {
         "use_cache": config.gradient_checkpointing,
         "low_cpu_mem_usage": True,
     }
-    if load_on_gpu:
+    if device.type == "cuda":
         # Stream weights directly to GPU to avoid CPU RAM spikes during load.
         load_kwargs["device_map"] = device
 
@@ -54,7 +53,7 @@ def get_model(config: TrainingConfig, device: torch.device):
         raise ValueError(f"Invalid training type: {config.training_type}")
 
     model.to(eval(config.dtype))
-    if not load_on_gpu:
+    if config.use_tt:
         model.to(device)
 
     # Per-tensor weight dtype overrides must be registered before torch.compile

--- a/env/gpu_requirements.txt
+++ b/env/gpu_requirements.txt
@@ -2,4 +2,4 @@
 torch==2.7.0
 torch-xla @ https://storage.googleapis.com/pytorch-xla-releases/wheels/cuda/12.6/torch_xla-2.7.0-cp311-cp311-manylinux_2_28_x86_64.whl
 torchvision
-git+https://github.com/erfanzar/EasyDeL.git@77ced9d2f2ab6a3d705936d26112eb97d9f9e64a
+easydel[cuda]

--- a/env/gpu_requirements.txt
+++ b/env/gpu_requirements.txt
@@ -2,4 +2,4 @@
 torch==2.7.0
 torch-xla @ https://storage.googleapis.com/pytorch-xla-releases/wheels/cuda/12.6/torch_xla-2.7.0-cp311-cp311-manylinux_2_28_x86_64.whl
 torchvision
-easydel[cuda]
+git+https://github.com/erfanzar/EasyDeL.git@77ced9d2f2ab6a3d705936d26112eb97d9f9e64a


### PR DESCRIPTION
### Issue
N/A

### Problem description
GPU setup is broken for many reasons. Runs need many patches to even setup environment.

### What's Changed
This PR adds 3 fixes:
- Change for EasyDel loading. (triton versions requirements defer for torch and easydel commit). This fix is now moved to https://github.com/tenstorrent/tt-blacksmith/pull/639, so we need to merge this PR after it.
- Change loading of models from huggingface. (GPU machines have less host memory then TT)
- Change for lazy load of kornia. (torch 2.7.0 clashes with kornia)

### Checklist
- [x] GPU setup is working out-of-box
- [x] Changes do not break TT runs
