### PR TITLE
Fix EasyDel GPU Dependencies

### DIFF
--- a/blacksmith/experiments/easydel/qwen/lora/README.md
+++ b/blacksmith/experiments/easydel/qwen/lora/README.md
@@ -33,11 +33,10 @@ source env/activate --gpu
 
 EasyDel is pulled in automatically by `env/xla_requirements.txt`, pinned to the validated commit.
 
-For **GPU baseline** runs, also install EasyDel manually (the GPU env does not pin it) plus the JAX CUDA plugin (`--no-deps` avoids a cuDNN version conflict with torch):
+For **GPU baseline** runs, also run:
 
 ```bash
-pip install git+https://github.com/erfanzar/EasyDeL.git@77ced9d2f2ab6a3d705936d26112eb97d9f9e64a
-pip install --no-deps jax-cuda12-plugin==0.7.1 jax-cuda12-pjrt==0.7.1
+bash blacksmith/experiments/easydel/setup_gpu_requirements.sh
 ```
 
 ## Training

--- a/blacksmith/experiments/easydel/setup_gpu_requirements.sh
+++ b/blacksmith/experiments/easydel/setup_gpu_requirements.sh
@@ -1,0 +1,29 @@
+set -e
+
+# TODO(pglusac): This is a temporary workaround. Refactor once we figure out what to do with torch-xla GPU package.
+echo "Installing EasyDeL without deps (avoids triton conflict with torch)..."
+pip install --no-deps \
+    git+https://github.com/erfanzar/EasyDeL.git@77ced9d2f2ab6a3d705936d26112eb97d9f9e64a
+
+echo "Installing EasyDeL dependencies"
+pip install \
+    "jax==0.7.1" \
+    "jaxlib==0.7.1" \
+    "flax==0.11.0" \
+    "eformer>=0.0.62" \
+    "einops~=0.8.0" \
+    "optax>=0.2.2" \
+    "jaxtyping~=0.3.2" \
+    "ray[default]==2.34.0" \
+    "fastapi>=0.115.2" \
+    "uvloop==0.21.0" \
+    "uvicorn[standard]>=0.32.0" \
+    "jinja2>=3.1.5" \
+    "grain~=0.2.11" \
+    "datasets>=3.6.0" \
+    "gcsfs>=2024.2,<2026" \
+    "zstandard>=0.23.0" \
+    "msgspec~=0.19.0" \
+    "partial-json-parser>=0.2.1.1.post6" \
+    "google-api-python-client>=2.179.0" \
+    "cryptography>=45.0.6"

--- a/blacksmith/experiments/easydel/setup_gpu_requirements.sh
+++ b/blacksmith/experiments/easydel/setup_gpu_requirements.sh
@@ -1,6 +1,6 @@
 set -e
 
-# TODO(pglusac): This is a temporary workaround. Refactor once we figure out what to do with torch-xla GPU package.
+# TODO(pglusacTT): This is a temporary workaround. Refactor once we figure out what to do with torch-xla GPU package.
 echo "Installing EasyDeL without deps (avoids triton conflict with torch)..."
 pip install --no-deps \
     git+https://github.com/erfanzar/EasyDeL.git@77ced9d2f2ab6a3d705936d26112eb97d9f9e64a

--- a/blacksmith/experiments/easydel/setup_gpu_requirements.sh
+++ b/blacksmith/experiments/easydel/setup_gpu_requirements.sh
@@ -1,7 +1,7 @@
 set -e
 
-# TODO(pglusacTT): This is a temporary workaround. Refactor once we figure out what to do with torch-xla GPU package.
-echo "Installing EasyDeL without deps (avoids triton conflict with torch)..."
+# TODO(pglusacTT): This is a temporary workaround due to triton conflict with torch.
+echo "Installing EasyDeL without deps..."
 pip install --no-deps \
     git+https://github.com/erfanzar/EasyDeL.git@77ced9d2f2ab6a3d705936d26112eb97d9f9e64a
 

--- a/env/gpu_requirements.txt
+++ b/env/gpu_requirements.txt
@@ -2,4 +2,3 @@
 torch==2.7.0
 torch-xla @ https://storage.googleapis.com/pytorch-xla-releases/wheels/cuda/12.6/torch_xla-2.7.0-cp311-cp311-manylinux_2_28_x86_64.whl
 torchvision
-git+https://github.com/erfanzar/EasyDeL.git@77ced9d2f2ab6a3d705936d26112eb97d9f9e64a


### PR DESCRIPTION
### Issue
Closes https://github.com/tenstorrent/tt-blacksmith/issues/631

### Bug Description
Running `source env/activate --gpu` was giving an error because of triton dependency clash between torch-xla and easydel.

### What's Changed
Make ED deps a separate script.

### Checklist
- [ ] Bug is reproducible before the fix
- [ ] Fix resolves the bug
- [ ] Tests pass and updated if needed
- [ ] No new bugs introduced
- [ ] Documentation updated if needed
