### PR TITLE
[Trainer] Add LoraLLMTrainer and Default Training Structure

### DIFF
--- a/blacksmith/tools/trainer/callback.py
+++ b/blacksmith/tools/trainer/callback.py
@@ -6,52 +6,56 @@ from abc import ABC
 
 class Callback(ABC):
     # Training callbacks.
-    def on_train_start(self, trainer):
+    def on_train_start(self, trainer, **kwargs):
         pass
 
-    def on_train_end(self, trainer):
+    def on_train_end(self, trainer, **kwargs):
         pass
 
-    def on_train_epoch_start(self, trainer):
+    def on_train_epoch_start(self, trainer, **kwargs):
         pass
 
-    def on_train_epoch_end(self, trainer):
+    def on_train_epoch_end(self, trainer, **kwargs):
         pass
 
-    def on_train_batch_start(self, trainer, batch):
+    def on_train_batch_start(self, trainer, batch, **kwargs):
         pass
 
-    def on_train_batch_end(self, trainer):
+    def on_train_batch_end(self, trainer, **kwargs):
         pass
 
     # Validation callbacks.
-    def on_validation_start(self, trainer):
+    def on_validation_start(self, trainer, **kwargs):
         pass
 
-    def on_validation_batch_start(self, trainer, batch):
+    def on_validation_batch_start(self, trainer, batch, **kwargs):
         pass
 
-    def on_validation_batch_end(self, trainer, batch):
+    def on_validation_batch_end(self, trainer, batch, loss, **kwargs):
         pass
 
-    def on_validation_end(self, trainer):
+    def on_validation_end(self, trainer, val_loss, **kwargs):
         pass
 
     # Forward / Backward / Optimizer Step callbacks.
-    def on_forward_start(self, trainer, batch):
+    def on_forward_start(self, trainer, batch, **kwargs):
         pass
 
-    def on_forward_end(self, trainer, loss):
+    def on_forward_end(self, trainer, loss, **kwargs):
         pass
 
-    def on_backward_start(self, trainer, loss):
+    def on_backward_start(self, trainer, loss, **kwargs):
         pass
 
-    def on_backward_end(self, trainer):
+    def on_backward_end(self, trainer, **kwargs):
         pass
 
-    def on_optimizer_step_start(self, trainer):
+    def on_optimizer_step_start(self, trainer, **kwargs):
         pass
 
-    def on_optimizer_step_end(self, trainer):
+    def on_optimizer_step_end(self, trainer, **kwargs):
+        pass
+
+    # Error callback. Called when training fails with an exception.
+    def on_error(self, trainer, exception, **kwargs):
         pass

--- a/blacksmith/tools/trainer/callback.py
+++ b/blacksmith/tools/trainer/callback.py
@@ -6,56 +6,56 @@ from abc import ABC
 
 class Callback(ABC):
     # Training callbacks.
-    def on_train_start(self, trainer, **kwargs):
+    def on_train_start(self, trainer):
         pass
 
-    def on_train_end(self, trainer, **kwargs):
+    def on_train_end(self, trainer):
         pass
 
-    def on_train_epoch_start(self, trainer, **kwargs):
+    def on_train_epoch_start(self, trainer):
         pass
 
-    def on_train_epoch_end(self, trainer, **kwargs):
+    def on_train_epoch_end(self, trainer):
         pass
 
-    def on_train_batch_start(self, trainer, batch, **kwargs):
+    def on_train_batch_start(self, trainer, batch):
         pass
 
-    def on_train_batch_end(self, trainer, **kwargs):
+    def on_train_batch_end(self, trainer):
         pass
 
     # Validation callbacks.
-    def on_validation_start(self, trainer, **kwargs):
+    def on_validation_start(self, trainer):
         pass
 
-    def on_validation_batch_start(self, trainer, batch, **kwargs):
+    def on_validation_batch_start(self, trainer, batch):
         pass
 
-    def on_validation_batch_end(self, trainer, batch, loss, **kwargs):
+    def on_validation_batch_end(self, trainer, batch, loss):
         pass
 
-    def on_validation_end(self, trainer, val_loss, **kwargs):
+    def on_validation_end(self, trainer, val_loss):
         pass
 
     # Forward / Backward / Optimizer Step callbacks.
-    def on_forward_start(self, trainer, batch, **kwargs):
+    def on_forward_start(self, trainer, batch):
         pass
 
-    def on_forward_end(self, trainer, loss, **kwargs):
+    def on_forward_end(self, trainer, loss):
         pass
 
-    def on_backward_start(self, trainer, loss, **kwargs):
+    def on_backward_start(self, trainer, loss):
         pass
 
-    def on_backward_end(self, trainer, **kwargs):
+    def on_backward_end(self, trainer):
         pass
 
-    def on_optimizer_step_start(self, trainer, **kwargs):
+    def on_optimizer_step_start(self, trainer):
         pass
 
-    def on_optimizer_step_end(self, trainer, **kwargs):
+    def on_optimizer_step_end(self, trainer):
         pass
 
-    # Error callback. Called when training fails with an exception.
-    def on_error(self, trainer, exception, **kwargs):
+    # Error callback.
+    def on_error(self, trainer, exception):
         pass

--- a/blacksmith/tools/trainer/configs/__init__.py
+++ b/blacksmith/tools/trainer/configs/__init__.py
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+from blacksmith.tools.trainer.configs.base import TrainerConfig
+from blacksmith.tools.trainer.configs.lora_llm import LoraLLMConfig
+
+__all__ = [
+    "TrainerConfig",
+    "LoraLLMConfig",
+]

--- a/blacksmith/tools/trainer/configs/base.py
+++ b/blacksmith/tools/trainer/configs/base.py
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+from typing import List, Optional, Tuple
+
+from pydantic import BaseModel, Field
+
+from blacksmith.tools.test_config import TestConfig
+
+
+class TrainerConfig(BaseModel):
+    """
+    Configuration for the :class:`~blacksmith.tools.trainer.trainer.Trainer`.
+
+    Root of the trainer-config hierarchy. Holds the strategy-agnostic fields the
+    generic training machinery consumes (the training loop, optimizer and device
+    manager). Concrete per-strategy configs (e.g. ``LoraLLMConfig``) extend this
+    with the fields their trainer needs.
+    """
+
+    # Dataset settings
+    dataset_id: str = Field(default="dataset_id")
+
+    # Model settings
+    model_name: str = Field(default="model_name")
+    dtype: str = Field(default="dtype")
+
+    # Training hyperparameters
+    learning_rate: float = Field(default=2e-5, gt=0)
+    batch_size: int = Field(default=8, gt=0)
+    num_epochs: int = Field(default=1, gt=0)
+    optim: str = Field(default="adamw_torch")
+    weight_decay: float = Field(default=0.0, ge=0)
+    gradient_accumulation_steps: int = Field(default=1, ge=1)
+    gradient_checkpointing: bool = Field(default=False)
+    training_type: str = Field(default="lora")
+
+    # Validation settings
+    val_steps_freq: int = Field(default=25, ge=1)
+
+    # Reproducibility settings
+    framework: str = Field(default="pytorch")  # Dispatch key for ReproducibilityManager.
+    seed: int = Field(default=23)
+    deterministic: bool = Field(default=False)
+
+    # Device / sharding settings
+    use_tt: bool = Field(default=True)
+    mesh_shape: Optional[list[int]] = Field(default=None)  # Use None for single device, [x,y] for 2D mesh.
+    mesh_axis_names: Optional[list[str]] = Field(
+        default=None
+    )  # Use None for single device, ["data", "model"] for 2D mesh.
+    input_sharding_dim: Optional[str] = Field(
+        default=None
+    )  # If defined, we will shard inputs along this mesh axis dimension.
+    # Model sharding patterns (regex pattern based - matches module names).
+    # Format: List of tuples (regex_pattern, sharding_spec_tuple).
+    model_sharding_patterns: Optional[List[Tuple[str, Tuple[Optional[str], ...]]]] = Field(default=None)

--- a/blacksmith/tools/trainer/configs/base.py
+++ b/blacksmith/tools/trainer/configs/base.py
@@ -8,12 +8,9 @@ from pydantic import BaseModel, Field
 
 class TrainerConfig(BaseModel):
     """
-    Configuration for the :class:`~blacksmith.tools.trainer.trainer.Trainer`.
+    Base trainer configuration.
 
-    Root of the trainer-config hierarchy. Holds the strategy-agnostic fields the
-    generic training machinery consumes (the training loop, optimizer and device
-    manager). Concrete per-strategy configs (e.g. ``LoraLLMConfig``) extend this
-    with the fields their trainer needs.
+    Holds fields that are common to all trainer configurations.
     """
 
     # Dataset settings
@@ -37,19 +34,13 @@ class TrainerConfig(BaseModel):
     val_steps_freq: int = Field(default=25, ge=1)
 
     # Reproducibility settings
-    framework: str = Field(default="pytorch")  # Dispatch key for ReproducibilityManager.
+    framework: str = Field(default="pytorch")
     seed: int = Field(default=23)
     deterministic: bool = Field(default=False)
 
     # Device / sharding settings
     use_tt: bool = Field(default=True)
-    mesh_shape: Optional[list[int]] = Field(default=None)  # Use None for single device, [x,y] for 2D mesh.
-    mesh_axis_names: Optional[list[str]] = Field(
-        default=None
-    )  # Use None for single device, ["data", "model"] for 2D mesh.
-    input_sharding_dim: Optional[str] = Field(
-        default=None
-    )  # If defined, we will shard inputs along this mesh axis dimension.
-    # Model sharding patterns (regex pattern based - matches module names).
-    # Format: List of tuples (regex_pattern, sharding_spec_tuple).
+    mesh_shape: Optional[list[int]] = Field(default=None)
+    mesh_axis_names: Optional[list[str]] = Field(default=None)
+    input_sharding_dim: Optional[str] = Field(default=None)
     model_sharding_patterns: Optional[List[Tuple[str, Tuple[Optional[str], ...]]]] = Field(default=None)

--- a/blacksmith/tools/trainer/configs/base.py
+++ b/blacksmith/tools/trainer/configs/base.py
@@ -5,8 +5,6 @@ from typing import List, Optional, Tuple
 
 from pydantic import BaseModel, Field
 
-from blacksmith.tools.test_config import TestConfig
-
 
 class TrainerConfig(BaseModel):
     """

--- a/blacksmith/tools/trainer/configs/lora_llm.py
+++ b/blacksmith/tools/trainer/configs/lora_llm.py
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+from pydantic import Field
+
+from blacksmith.tools.trainer.configs.base import TrainerConfig
+
+
+class LoraLLMConfig(TrainerConfig):
+    """
+    Configuration for :class:`~blacksmith.tools.trainer.strategies.lora_llm_trainer.LoraLLMTrainer`.
+
+    Extends :class:`TrainerConfig` with the LoRA-specific fields needed to
+    finalize the LoRA LLM trainer (consumed by ``get_model``, ``get_dataset``
+    and the forward/loss computation).
+    """
+
+    # Model settings
+    max_length: int = Field(default=128, gt=0)
+
+    # Training hyperparameters
+    ignored_index: int = Field(default=-100)  # Label id ignored by the cross-entropy loss.
+
+    # LoRA setup
+    lora_r: int = Field(default=8, gt=0)
+    lora_alpha: int = Field(default=16, gt=0)
+    lora_target_modules: list[str] = Field(default_factory=lambda: ["all-linear"])
+    lora_task_type: str = Field(default="CAUSAL_LM")

--- a/blacksmith/tools/trainer/configs/lora_llm.py
+++ b/blacksmith/tools/trainer/configs/lora_llm.py
@@ -8,11 +8,7 @@ from blacksmith.tools.trainer.configs.base import TrainerConfig
 
 class LoraLLMConfig(TrainerConfig):
     """
-    Configuration for :class:`~blacksmith.tools.trainer.strategies.lora_llm_trainer.LoraLLMTrainer`.
-
-    Extends :class:`TrainerConfig` with the LoRA-specific fields needed to
-    finalize the LoRA LLM trainer (consumed by ``get_model``, ``get_dataset``
-    and the forward/loss computation).
+    Configuration for the LoRA LLM trainer.
     """
 
     # Model settings

--- a/blacksmith/tools/trainer/examples/lora_llm/data_parallel/llama_3_2_1b_sst2.yaml
+++ b/blacksmith/tools/trainer/examples/lora_llm/data_parallel/llama_3_2_1b_sst2.yaml
@@ -1,0 +1,34 @@
+# Dataset settings
+dataset_id: "sst2"
+
+# Model settings
+model_name: "meta-llama/Llama-3.2-1B"
+max_length: 64
+dtype: "torch.bfloat16"
+
+# Training hyperparameters
+learning_rate: 1e-4
+batch_size: 16
+gradient_accumulation_steps: 1
+num_epochs: 1
+ignored_index: -100
+
+# LoRA setup
+lora_r: 4
+lora_alpha: 8
+lora_target_modules: ["q_proj", "v_proj", "k_proj", "o_proj"]
+lora_task_type: "CAUSAL_LM"
+
+# Validation settings
+val_steps_freq: 10
+
+mesh_shape: [1, 2]  # [model, batch]
+mesh_axis_names: ["model", "batch"]
+input_sharding_dim: "batch"
+
+# Reproducibility settings
+seed: 23
+deterministic: False
+
+# Device settings
+use_tt: True

--- a/blacksmith/tools/trainer/examples/lora_llm/data_parallel/llama_3_2_1b_sst2.yaml
+++ b/blacksmith/tools/trainer/examples/lora_llm/data_parallel/llama_3_2_1b_sst2.yaml
@@ -22,7 +22,7 @@ lora_task_type: "CAUSAL_LM"
 # Validation settings
 val_steps_freq: 10
 
-mesh_shape: [1, 2]  # [model, batch]
+mesh_shape: [1, 2]
 mesh_axis_names: ["model", "batch"]
 input_sharding_dim: "batch"
 

--- a/blacksmith/tools/trainer/examples/lora_llm/single_chip/llama_3_2_1b_sst2.yaml
+++ b/blacksmith/tools/trainer/examples/lora_llm/single_chip/llama_3_2_1b_sst2.yaml
@@ -1,0 +1,30 @@
+# Dataset settings
+dataset_id: "sst2"
+
+# Model settings
+model_name: "meta-llama/Llama-3.2-1B"
+max_length: 64
+dtype: "torch.bfloat16"
+
+# Training hyperparameters
+learning_rate: 1e-4
+batch_size: 16
+gradient_accumulation_steps: 1
+num_epochs: 1
+ignored_index: -100
+
+# LoRA setup
+lora_r: 4
+lora_alpha: 8
+lora_target_modules: ["q_proj", "v_proj"]
+lora_task_type: "CAUSAL_LM"
+
+# Validation settings
+val_steps_freq: 10
+
+# Reproducibility settings
+seed: 23
+deterministic: False
+
+# Device settings - single chip (no mesh).
+use_tt: True

--- a/blacksmith/tools/trainer/examples/lora_llm/tensor_parallel/llama_3_2_1b_sst2.yaml
+++ b/blacksmith/tools/trainer/examples/lora_llm/tensor_parallel/llama_3_2_1b_sst2.yaml
@@ -14,9 +14,6 @@ num_epochs: 1
 ignored_index: -100
 
 # LoRA setup
-# Only q_proj/v_proj are LoRA-wrapped so the sharding patterns below match the
-# resulting module names (LoRA targets expose `.base_layer`/`.lora_B.default`,
-# while frozen projections keep their plain name).
 lora_r: 4
 lora_alpha: 8
 lora_target_modules: ["q_proj", "v_proj"]
@@ -25,7 +22,7 @@ lora_task_type: "CAUSAL_LM"
 # Validation settings
 val_steps_freq: 50
 
-mesh_shape: [1, 2]  # [batch, model]
+mesh_shape: [1, 2]
 mesh_axis_names: ["batch", "model"]
 input_sharding_dim: null
 model_sharding_patterns:

--- a/blacksmith/tools/trainer/examples/lora_llm/tensor_parallel/llama_3_2_1b_sst2.yaml
+++ b/blacksmith/tools/trainer/examples/lora_llm/tensor_parallel/llama_3_2_1b_sst2.yaml
@@ -1,0 +1,49 @@
+# Dataset settings
+dataset_id: "sst2"
+
+# Model settings
+model_name: "meta-llama/Llama-3.2-1B"
+max_length: 64
+dtype: "torch.bfloat16"
+
+# Training hyperparameters
+learning_rate: 1e-4
+batch_size: 16
+gradient_accumulation_steps: 1
+num_epochs: 1
+ignored_index: -100
+
+# LoRA setup
+# Only q_proj/v_proj are LoRA-wrapped so the sharding patterns below match the
+# resulting module names (LoRA targets expose `.base_layer`/`.lora_B.default`,
+# while frozen projections keep their plain name).
+lora_r: 4
+lora_alpha: 8
+lora_target_modules: ["q_proj", "v_proj"]
+lora_task_type: "CAUSAL_LM"
+
+# Validation settings
+val_steps_freq: 50
+
+mesh_shape: [1, 2]  # [batch, model]
+mesh_axis_names: ["batch", "model"]
+input_sharding_dim: null
+model_sharding_patterns:
+  # === Attention ===
+  - ['\.self_attn\.q_proj\.base_layer$',      ["model", null]]
+  - ['\.self_attn\.q_proj\.lora_B\.default$', ["model", null]]
+  - ['\.self_attn\.k_proj$',                  ["model", null]]
+  - ['\.self_attn\.v_proj\.base_layer$',      ["model", null]]
+  - ['\.self_attn\.v_proj\.lora_B\.default$', ["model", null]]
+  - ['\.self_attn\.o_proj$',                  [null, "model"]]
+  # === MLP ===
+  - ['\.mlp\.gate_proj$', ["model", null]]
+  - ['\.mlp\.up_proj$',   ["model", null]]
+  - ['\.mlp\.down_proj$', [null, "model"]]
+
+# Reproducibility settings
+seed: 23
+deterministic: False
+
+# Device settings
+use_tt: True

--- a/blacksmith/tools/trainer/examples/lora_llm/train.py
+++ b/blacksmith/tools/trainer/examples/lora_llm/train.py
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Example runner for :class:`LoraLLMTrainer`.
+
+Runs the LoRA LLM trainer from a YAML config so you can check that the shared
+``Trainer`` works across device setups (single chip / tensor parallel / data
+parallel). Pick the config with ``--config``; it defaults to the single-chip one.
+
+    python blacksmith/tools/trainer/examples/lora_llm/train.py --config blacksmith/tools/trainer/examples/lora_llm/tensor_parallel/llama_3_2_1b_sst2.yaml
+"""
+from pathlib import Path
+
+from blacksmith.tools.cli import generate_config, parse_cli_options
+from blacksmith.tools.trainer.configs import LoraLLMConfig
+from blacksmith.tools.trainer.strategies import LoraLLMTrainer
+
+if __name__ == "__main__":
+    default_config = Path(__file__).parent / "single_chip" / "llama_3_2_1b_sst2.yaml"
+    args = parse_cli_options(default_config=default_config)
+    config: LoraLLMConfig = generate_config(LoraLLMConfig, args.config)
+
+    trainer = LoraLLMTrainer()
+    trainer.setup(config)
+    trainer.train()

--- a/blacksmith/tools/trainer/examples/lora_llm/train.py
+++ b/blacksmith/tools/trainer/examples/lora_llm/train.py
@@ -1,14 +1,6 @@
 # SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
 #
 # SPDX-License-Identifier: Apache-2.0
-"""Example runner for :class:`LoraLLMTrainer`.
-
-Runs the LoRA LLM trainer from a YAML config so you can check that the shared
-``Trainer`` works across device setups (single chip / tensor parallel / data
-parallel). Pick the config with ``--config``; it defaults to the single-chip one.
-
-    python blacksmith/tools/trainer/examples/lora_llm/train.py --config blacksmith/tools/trainer/examples/lora_llm/tensor_parallel/llama_3_2_1b_sst2.yaml
-"""
 from pathlib import Path
 
 from blacksmith.tools.cli import generate_config, parse_cli_options

--- a/blacksmith/tools/trainer/strategies/lora_llm_trainer.py
+++ b/blacksmith/tools/trainer/strategies/lora_llm_trainer.py
@@ -1,10 +1,46 @@
 # SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
 #
 # SPDX-License-Identifier: Apache-2.0
+from typing import Any
 
+import torch
+import torch.nn.functional as F
+
+from blacksmith.datasets.torch.dataset_utils import get_dataset
+from blacksmith.models.torch.huggingface.hf_models import get_model
+from blacksmith.tools.torch_helpers import collate_fn_for_causal_lm
 from blacksmith.tools.trainer.trainer import Trainer
 
 
-# TODO(mmilosevicTT): Implement Lora Adapter Layer LLM Trainer. See https://github.com/tenstorrent/tt-blacksmith/issues/617
 class LoraLLMTrainer(Trainer):
-    pass
+    """
+    Trainer for parameter-efficient fine-tuning of causal LLMs.
+
+    Provides the strategy-specific pieces (model, dataloaders and the
+    forward/loss computation) on top of the generic training loop, optimizer,
+    gradient accumulation, validation and callback orchestration implemented in
+    :class:`~blacksmith.tools.trainer.trainer.Trainer`.
+    """
+
+    def _load_model(self) -> torch.nn.Module:
+        return get_model(self.config, self.device_manager.device, compile_model=True)
+
+    def _load_dataloaders(self) -> tuple:
+        train_dataset = get_dataset(config=self.config, split="train", collate_fn=collate_fn_for_causal_lm)
+        val_dataset = get_dataset(config=self.config, split="validation", collate_fn=collate_fn_for_causal_lm)
+
+        return train_dataset.get_dataloader(), val_dataset.get_dataloader()
+
+    def _forward(self, batch: Any) -> torch.Tensor:
+        output = self.model(input_ids=batch["input_ids"], attention_mask=batch["attention_mask"])
+
+        # Shift logits for causal LM: position t predicts token t+1. Labels are
+        # already shifted in the collate fn, so we drop the final logit here.
+        shift_logits = output.logits[:, :-1, :].contiguous()
+        labels = batch["labels"]
+
+        return F.cross_entropy(
+            shift_logits.reshape(-1, shift_logits.size(-1)),
+            labels.reshape(-1),
+            ignore_index=self.config.ignored_index,
+        )

--- a/blacksmith/tools/trainer/strategies/lora_llm_trainer.py
+++ b/blacksmith/tools/trainer/strategies/lora_llm_trainer.py
@@ -5,6 +5,7 @@ from typing import Any
 
 import torch
 import torch.nn.functional as F
+from torch.utils.data import DataLoader
 
 from blacksmith.datasets.torch.dataset_utils import get_dataset
 from blacksmith.models.torch.huggingface.hf_models import get_model
@@ -25,7 +26,7 @@ class LoraLLMTrainer(Trainer):
     def _load_model(self) -> torch.nn.Module:
         return get_model(self.config, self.device_manager.device, compile_model=True)
 
-    def _load_dataloaders(self) -> tuple:
+    def _load_dataloaders(self) -> tuple[DataLoader, DataLoader]:
         train_dataset = get_dataset(config=self.config, split="train", collate_fn=collate_fn_for_causal_lm)
         val_dataset = get_dataset(config=self.config, split="validation", collate_fn=collate_fn_for_causal_lm)
 

--- a/blacksmith/tools/trainer/strategies/lora_llm_trainer.py
+++ b/blacksmith/tools/trainer/strategies/lora_llm_trainer.py
@@ -15,12 +15,7 @@ from blacksmith.tools.trainer.trainer import Trainer
 
 class LoraLLMTrainer(Trainer):
     """
-    Trainer for parameter-efficient fine-tuning of causal LLMs.
-
-    Provides the strategy-specific pieces (model, dataloaders and the
-    forward/loss computation) on top of the generic training loop, optimizer,
-    gradient accumulation, validation and callback orchestration implemented in
-    :class:`~blacksmith.tools.trainer.trainer.Trainer`.
+    Trainer for parameter-efficient fine-tuning of causal LLMs using LoRA.
     """
 
     def _load_model(self) -> torch.nn.Module:

--- a/blacksmith/tools/trainer/trainer.py
+++ b/blacksmith/tools/trainer/trainer.py
@@ -7,6 +7,7 @@ from typing import Any, Union
 
 import torch
 import torch_xla
+from torch.utils.data import DataLoader
 from tqdm import tqdm
 
 from blacksmith.tools.device_manager import DeviceManager
@@ -65,7 +66,7 @@ class Trainer(ABC):
         pass
 
     @abstractmethod
-    def _load_dataloaders(self) -> tuple:
+    def _load_dataloaders(self) -> tuple[DataLoader, DataLoader | None]:
         """
         Build and return the ``(train_dataloader, val_dataloader)`` pair.
 

--- a/blacksmith/tools/trainer/trainer.py
+++ b/blacksmith/tools/trainer/trainer.py
@@ -36,14 +36,6 @@ class Trainer(ABC):
     ) -> None:
         """
         Setup the trainer with the given configuration.
-
-        Initializes the strategy-independent pieces (config, reproducibility and
-        device manager), then loads the strategy-specific model, dataloaders and
-        optimizer via the
-        ``_load_model`` / ``_load_dataloaders`` / ``_load_optimizer`` hooks.
-
-        Always cleans up first so setup can run from a clean state (this also
-        initializes ``global_step`` / ``epoch``).
         """
         if self.config is not None:
             self.cleanup()
@@ -61,7 +53,7 @@ class Trainer(ABC):
     @abstractmethod
     def _load_model(self) -> torch.nn.Module:
         """
-        Build and return compiled model to train if using TT, otherwise return the model.
+        Build and return compiled model to train.
         """
         pass
 
@@ -89,14 +81,6 @@ class Trainer(ABC):
         )
 
     def train(self) -> None:
-        """
-        Run the training loop.
-
-        The loop is generic: subclasses provide the model-specific behaviour
-        through the ``_forward`` / ``_backward`` / ``_optimizer_step`` extension
-        points, while this method orchestrates epochs, gradient accumulation,
-        inline validation and callback hooks.
-        """
         self.callback_handler("on_train_start")
         # `on_train_start` callbacks need to guard against having a config.
         if self.config is None:
@@ -173,19 +157,11 @@ class Trainer(ABC):
 
                 self.callback_handler("on_train_epoch_end")
         except Exception as exception:
-            self.callback_handler("on_error", exception)
+            self.callback_handler("on_error", trainer=self, exception=exception)
         finally:
             self.callback_handler("on_train_end")
 
     def validate(self) -> None:
-        """
-        Run the validation loop over ``self.val_dataloader``.
-
-        Reuses ``_forward`` under ``torch.no_grad`` (the forward pass is
-        identical to training), computes the mean loss and passes it to the
-        validation callback hooks. Callers are responsible for ensuring a
-        validation dataloader exists before invoking this.
-        """
         self.model.eval()
         self.callback_handler("on_validation_start")
 

--- a/blacksmith/tools/trainer/trainer.py
+++ b/blacksmith/tools/trainer/trainer.py
@@ -5,9 +5,15 @@ from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from typing import Any, Union
 
-from blacksmith.tools.templates.configs import TrainingConfig
+import torch
+import torch_xla
+from tqdm import tqdm
+
+from blacksmith.tools.device_manager import DeviceManager
+from blacksmith.tools.reproducibility_manager import ReproducibilityManager
 from blacksmith.tools.trainer.callback import Callback
 from blacksmith.tools.trainer.callbacks_handler import CallbackHandler
+from blacksmith.tools.trainer.configs.base import TrainerConfig
 from blacksmith.tools.trainer.utils import normalize_callbacks
 
 
@@ -16,37 +22,231 @@ class Trainer(ABC):
         self,
         callbacks: Union[Callback, Sequence[Callback], None] = None,
     ):
-        self.config = None
         self.callback_handler = CallbackHandler(self, normalize_callbacks(callbacks))
+        self.config: TrainerConfig | None = None
+        self.reproducibility_manager: ReproducibilityManager | None = None
+        self.global_step: int = 0
+        self.epoch: int = 0
 
-    @abstractmethod
     def setup(
         self,
-        config: TrainingConfig | None = None,
+        config: TrainerConfig | None = None,
         **kwargs: Any,
     ) -> None:
         """
         Setup the trainer with the given configuration.
+
+        Initializes the strategy-independent pieces (config, reproducibility and
+        device manager), then loads the strategy-specific model, dataloaders and
+        optimizer via the
+        ``_load_model`` / ``_load_dataloaders`` / ``_load_optimizer`` hooks.
+
+        Always cleans up first so setup can run from a clean state (this also
+        initializes ``global_step`` / ``epoch``).
+        """
+        if self.config is not None:
+            self.cleanup()
+
+        self.config = config
+        if self.reproducibility_manager is None:
+            self.reproducibility_manager = ReproducibilityManager(config)
+        self.reproducibility_manager.setup()
+        self.device_manager = DeviceManager(config)
+
+        self.model = self._load_model()
+        self.train_dataloader, self.val_dataloader = self._load_dataloaders()
+        self.optimizer = self._load_optimizer()
+
+    @abstractmethod
+    def _load_model(self) -> torch.nn.Module:
+        """
+        Build and return compiled model to train if using TT, otherwise return the model.
         """
         pass
 
     @abstractmethod
+    def _load_dataloaders(self) -> tuple:
+        """
+        Build and return the ``(train_dataloader, val_dataloader)`` pair.
+
+        ``val_dataloader`` may be ``None`` if there is no validation set.
+        """
+        pass
+
+    def _load_optimizer(self) -> torch.optim.Optimizer:
+        """
+        Build and return the optimizer over the model's trainable parameters.
+
+        Defaults to AdamW; override for a different optimizer.
+        """
+        trainable_params = [p for p in self.model.parameters() if p.requires_grad]
+        return torch.optim.AdamW(
+            trainable_params,
+            lr=self.config.learning_rate,
+            weight_decay=self.config.weight_decay,
+            capturable=self.config.use_tt,
+        )
+
     def train(self) -> None:
         """
-        Train the model on the training dataset.
-        """
-        pass
+        Run the training loop.
 
-    @abstractmethod
+        The loop is generic: subclasses provide the model-specific behaviour
+        through the ``_forward`` / ``_backward`` / ``_optimizer_step`` extension
+        points, while this method orchestrates epochs, gradient accumulation,
+        inline validation and callback hooks.
+        """
+        self.callback_handler("on_train_start")
+        # `on_train_start` callbacks need to guard against having a config.
+        if self.config is None:
+            return
+
+        grad_accumulation_steps = self.config.gradient_accumulation_steps
+        # TODO(mmilosevicTT): Temporary running loss for debug prints; remove once
+        # default logging callback lands. See https://github.com/tenstorrent/tt-blacksmith/issues/621
+        running_loss = 0.0
+        running_count = 0
+        try:
+            # Initial validation pass before any optimizer steps.
+            if self.val_dataloader is not None:
+                self.validate()
+
+            for epoch in range(self.config.num_epochs):
+                self.epoch = epoch
+                self.callback_handler("on_train_epoch_start")
+
+                self.model.train()
+                self.optimizer.zero_grad()
+                accumulation_step = 0
+
+                progress = tqdm(self.train_dataloader, desc=f"Training (epoch {epoch})")
+                for batch in progress:
+                    self.callback_handler("on_train_batch_start", batch)
+
+                    # Shard inputs (data parallel) and model (tensor parallel) if configured.
+                    batch = self.device_manager.prepare_batch(batch)
+                    self.device_manager.shard_model(self.model)
+
+                    # Forward.
+                    self.callback_handler("on_forward_start", batch)
+                    loss = self._forward(batch)
+                    self.callback_handler("on_forward_end", loss)
+
+                    # Backward. Gradient-accumulation scaling is applied here so
+                    # _forward can stay identical between training and validation.
+                    self.callback_handler("on_backward_start", loss)
+                    self._backward(loss / grad_accumulation_steps)
+                    if self.config.use_tt:
+                        torch_xla.sync(wait=True)
+                    self.callback_handler("on_backward_end")
+
+                    accumulation_step += 1
+
+                    # Step the optimizer only after accumulating gradients.
+                    if accumulation_step == grad_accumulation_steps:
+                        self.callback_handler("on_optimizer_step_start")
+                        self._optimizer_step()
+                        self.callback_handler("on_optimizer_step_end")
+
+                        accumulation_step = 0
+                        self.global_step += 1
+                        progress.set_postfix(loss=loss.item())
+                        # TODO(mmilosevicTT): Temporary debug print (avg over 10 steps); remove once
+                        # default logging callback lands. See https://github.com/tenstorrent/tt-blacksmith/issues/621
+                        running_loss += loss.item()
+                        running_count += 1
+                        if self.global_step % 10 == 0:
+                            print(f"[step {self.global_step}] loss={running_loss / running_count:.4f}")
+                            running_loss = 0.0
+                            running_count = 0
+
+                        # Periodic inline validation.
+                        if (
+                            self.val_dataloader is not None
+                            and self.config.val_steps_freq
+                            and self.global_step % self.config.val_steps_freq == 0
+                        ):
+                            self.validate()
+
+                    self.callback_handler("on_train_batch_end")
+
+                self.callback_handler("on_train_epoch_end")
+        except Exception as exception:
+            self.callback_handler("on_error", exception)
+        finally:
+            self.callback_handler("on_train_end")
+
     def validate(self) -> None:
         """
-        Validate the model on the validation dataset.
+        Run the validation loop over ``self.val_dataloader``.
+
+        Reuses ``_forward`` under ``torch.no_grad`` (the forward pass is
+        identical to training), computes the mean loss and passes it to the
+        validation callback hooks. Callers are responsible for ensuring a
+        validation dataloader exists before invoking this.
+        """
+        self.model.eval()
+        self.callback_handler("on_validation_start")
+
+        total_loss = 0.0
+        num_batches = 0
+        with torch.no_grad():
+            for batch in tqdm(self.val_dataloader, desc="Validation"):
+                self.callback_handler("on_validation_batch_start", batch)
+
+                batch = self.device_manager.prepare_batch(batch)
+                self.device_manager.shard_model(self.model)
+
+                loss = self._forward(batch)
+                if self.config.use_tt:
+                    torch_xla.sync(wait=True)
+
+                total_loss += loss.item()
+                num_batches += 1
+                self.callback_handler("on_validation_batch_end", batch, loss)
+
+        val_loss = total_loss / num_batches if num_batches else 0.0
+        # TODO(mmilosevicTT): Temporary debug print; remove once default logging
+        # callback lands. See https://github.com/tenstorrent/tt-blacksmith/issues/621
+        print(f"[step {self.global_step}] val_loss={val_loss:.4f}")
+        self.callback_handler("on_validation_end", val_loss)
+        self.model.train()
+
+    @abstractmethod
+    def _forward(self, batch: Any) -> torch.Tensor:
+        """
+        Run a forward pass for a single batch and return the raw (unscaled) loss.
+
+        Shared by both ``train`` and ``validate``; gradient-accumulation scaling
+        is applied by ``train`` before backward.
         """
         pass
 
-    @abstractmethod
+    def _backward(self, loss: torch.Tensor) -> None:
+        """
+        Run the backward pass. Override for custom synchronization behaviour.
+        """
+        loss.backward()
+
+    def _optimizer_step(self) -> None:
+        """
+        Step the optimizer and reset gradients. Override for custom behaviour.
+        """
+        self.device_manager.optimizer_step(self.optimizer)
+        self.optimizer.zero_grad()
+
     def cleanup(self) -> None:
         """
-        Clean up any resources used by the trainer.
+        Clean up trainer state, releasing references to free resources.
+
+        Deletes all state except ``callback_handler`` and resets the trainer to
+        a not-set-up state (``config`` is ``None``).
         """
-        pass
+        preserved = {"callback_handler"}
+        for attr in list(self.__dict__):
+            if attr not in preserved:
+                delattr(self, attr)
+        self.config = None
+        self.reproducibility_manager = None
+        self.global_step = 0
+        self.epoch = 0


### PR DESCRIPTION
### Issue
Closes https://github.com/tenstorrent/tt-blacksmith/issues/617

### Problem description
This PR adds training through trainer class for lora llm models.

### What's Changed
- Added a generic `Trainer` base class (`blacksmith/tools/trainer/trainer.py`) that orchestrates the training loop: epochs, gradient accumulation, inline validation, optimizer setup, callback hooks, and device setup via `DeviceManager`.
- Integrated `ReproducibilityManager` into `Trainer.setup()` so seeds are set automatically from config (no manual seeding in scripts).
- Added `LoraLLMTrainer` strategy for parameter-efficient fine-tuning of causal LLMs (model/dataloader loading + forward/loss).
- Introduced a trainer config hierarchy: `TrainerConfig` (base) and `LoraLLMConfig`.
- Added an example runner (`examples/lora_llm/train.py`) plus SST-2 + Llama-3.2-1B configs for single-chip, tensor-parallel, and data-parallel setups.
- Updated the callback system to support the trainer lifecycle hooks.

### Checklist
- [x] New/Existing tests provide coverage for changes
