### PR TITLE
fix(docs): remove /tenstorrent-sandbox from CDN URLs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -84,7 +84,7 @@ exclude_patterns = []
 #
 
 _BLACKSMITH_BASE = "https://docs.tenstorrent.com/tt-blacksmith/"
-_GLOBAL_CSS = "https://tenstorrent.github.io/tenstorrent-sandbox/_static/tt_theme.css"
+_GLOBAL_CSS = "https://tenstorrent.github.io/_static/tt_theme.css"
 
 html_theme = "sphinx_rtd_theme"
 html_theme_options = {
@@ -102,11 +102,11 @@ html_last_updated_fmt = "%b %d, %Y"
 # Single-version site: published at a flat path, no version switcher.
 html_baseurl = _BLACKSMITH_BASE
 
-# Load global CSS from tenstorrent-sandbox CDN; local tt_theme.css adds overrides
+# Load global CSS from shared CDN; local tt_theme.css adds overrides
 html_css_files = [_GLOBAL_CSS]
 
 html_context = {
-    "logo_link_url": "https://tenstorrent.github.io/tenstorrent-sandbox/",
+    "logo_link_url": "https://tenstorrent.github.io/",
 }
 
 

--- a/docs/shared/_static/tt_theme.css
+++ b/docs/shared/_static/tt_theme.css
@@ -1,6 +1,6 @@
 /*
- * Global theme loaded from tenstorrent-sandbox CDN.
- * Full stylesheet: https://tenstorrent.github.io/tenstorrent-sandbox/_static/tt_theme.css
+ * Global theme loaded from shared CDN.
+ * Full stylesheet: https://tenstorrent.github.io/_static/tt_theme.css
  *
  * This file contains only TT-Blacksmith-specific overrides.
  * Base styles (fonts, colours, nav, sidebar, code blocks, version switcher)

--- a/docs/shared/_templates/layout.html
+++ b/docs/shared/_templates/layout.html
@@ -5,7 +5,7 @@
 {%- set _logo_url = logo_url|default(pathto('_static/' + (logo or ""), 1)) %}
 {%- set _root_doc = root_doc|default(master_doc) %}
 {#- Navbar core-content links point to the core sandbox hub so they resolve cross-site -#}
-{%- set _home = "https://tenstorrent.github.io/tenstorrent-sandbox/" %}
+{%- set _home = "https://tenstorrent.github.io/" %}
 <nav class="tt-top-nav" role="navigation" aria-label="Top navigation">
   <div class="tt-top-nav-left">
     <a href="{{ _home }}" class="tt-nav-logo">
@@ -197,13 +197,13 @@
 {%- block footer %}
 <script src="{{ pathto('_static/docs-toc.js', 1) }}"></script>
 {#- Keep the left sidebar from jumping to the top on every navigation -#}
-<script src="https://tenstorrent.github.io/tenstorrent-sandbox/_static/sidebar-scroll.js"></script>
+<script src="https://tenstorrent.github.io/_static/sidebar-scroll.js"></script>
 <script id="tt-search-script"
-        src="https://tenstorrent.github.io/tenstorrent-sandbox/_static/tt-search.js"
+        src="https://tenstorrent.github.io/_static/tt-search.js"
         data-search-url="{{ pathto('search') }}"
         data-search-api-base="https://csl860x2oj.execute-api.us-east-2.amazonaws.com/prod"
         data-search-source="{{ search_source_id | default('docs-tenstorrent', true) }}"
         data-site-base-url="{{ search_site_base_url | default('https://docs.tenstorrent.com/', true) }}"
-        data-kapa-src="https://tenstorrent.github.io/tenstorrent-sandbox/_static/kapa.js"
+        data-kapa-src="https://tenstorrent.github.io/_static/kapa.js"
         data-kapa-integration-id="c37e0bab-7623-43d7-bff1-daa52e901bbe"></script>
 {%- endblock %}


### PR DESCRIPTION
## Summary
- Removed `/tenstorrent-sandbox` path segment from all CDN URLs in docs config and templates
- URLs now point to `https://tenstorrent.github.io/` instead of `https://tenstorrent.github.io/tenstorrent-sandbox/`

## Files changed
| File | Change |
|------|--------|
| `docs/conf.py` | `_GLOBAL_CSS` and `logo_link_url` URLs updated |
| `docs/shared/_templates/layout.html` | `_home`, `sidebar-scroll.js`, `tt-search.js`, `kapa.js` URLs updated |
| `docs/shared/_static/tt_theme.css` | Comment URLs updated |

🤖 Generated with [Claude Code](https://claude.com/claude-code)