### PR TITLE
[PERF] Disable const-eval for LLaMA 3.1 8B single-chip LoRA

### DIFF
--- a/blacksmith/experiments/torch/llama/configs.py
+++ b/blacksmith/experiments/torch/llama/configs.py
@@ -103,3 +103,4 @@ class TrainingConfig(BaseTrainingConfig):
     test_config: Optional[TestConfig] = Field(default=None)
     enable_trace: bool = Field(default=False)
     trace_region_size: int = Field(default=1000000000, gt=0)  # DRAM region size (bytes) for runtime trace
+    enable_const_eval: bool = Field(default=True)

--- a/blacksmith/experiments/torch/llama/xla/lora/single_chip/llama_3_1_8b_sst2.yaml
+++ b/blacksmith/experiments/torch/llama/xla/lora/single_chip/llama_3_1_8b_sst2.yaml
@@ -3,13 +3,13 @@ dataset_id: "sst2"
 
 # Model settings
 model_name: "meta-llama/Llama-3.1-8B"
-max_length: 512
+max_length: 128
 dtype: "torch.bfloat16"
 
 # Training hyperparameters
 training_model_type: "lora"
 learning_rate: 1e-4
-batch_size: 1
+batch_size: 8
 num_epochs: 1
 ignored_index: -100
 

--- a/blacksmith/experiments/torch/llama/xla/lora/single_chip/llama_3_1_8b_sst2.yaml
+++ b/blacksmith/experiments/torch/llama/xla/lora/single_chip/llama_3_1_8b_sst2.yaml
@@ -3,13 +3,13 @@ dataset_id: "sst2"
 
 # Model settings
 model_name: "meta-llama/Llama-3.1-8B"
-max_length: 128
+max_length: 512
 dtype: "torch.bfloat16"
 
 # Training hyperparameters
 training_model_type: "lora"
 learning_rate: 1e-4
-batch_size: 8
+batch_size: 1
 num_epochs: 1
 ignored_index: -100
 
@@ -59,3 +59,4 @@ use_tt: True
 measure_e2e_time: False
 enable_trace: False
 trace_region_size: 1000000000 # DRAM region size (bytes) for runtime trace
+enable_const_eval: False

--- a/blacksmith/experiments/torch/llama/xla/train.py
+++ b/blacksmith/experiments/torch/llama/xla/train.py
@@ -199,13 +199,14 @@ def train(
                     torch_xla._XLAC._xla_sync_multi(tensors_to_sync, devices, wait=True)
                     # Optimizer will do unnecessary recompute if we don't clear the pending IRs after syncing the loss and grads.
                     torch_xla._XLAC._clear_pending_irs(torch_xla._XLAC._xla_get_default_device())
+                
+                running_loss += loss_.item()
+                accumulation_step += 1
 
                 # Only step the optimizer after accumulating gradients.
                 if accumulation_step == config.gradient_accumulation_steps:
                     device_manager.optimizer_step(optimizer)
 
-                    running_loss += step_loss.item()
-                    step_loss = None
                     accumulation_step = 0
                     global_step += 1
 

--- a/blacksmith/experiments/torch/llama/xla/train.py
+++ b/blacksmith/experiments/torch/llama/xla/train.py
@@ -166,7 +166,6 @@ def train(
         for epoch in range(config.num_epochs):
             accumulation_step = 0
             running_loss = 0.0
-            step_loss = None
 
             for batch in tqdm(train_dataloader, desc="Training"):
                 # Zero out gradients at the start of accumulation cycle

--- a/blacksmith/experiments/torch/llama/xla/train.py
+++ b/blacksmith/experiments/torch/llama/xla/train.py
@@ -290,7 +290,12 @@ if __name__ == "__main__":
     # fp32_dest_acc_en: accumulate partial results in FP32 to avoid precision loss.
     # math_fidelity hifi4: use all 4 mantissa phases for full precision multiplications.
     if config.use_tt:
-        compile_options = {"fp32_dest_acc_en": True, "math_fidelity": "hifi4", "enable_trace": config.enable_trace}
+        compile_options = {
+            "fp32_dest_acc_en": True,
+            "math_fidelity": "hifi4",
+            "enable_trace": config.enable_trace,
+            "enable_const_eval": config.enable_const_eval,
+        }
         if config.experimental_weight_dtype:
             compile_options["experimental_weight_dtype"] = config.experimental_weight_dtype
         torch_xla.set_custom_compile_options(compile_options)

--- a/blacksmith/experiments/torch/llama/xla/train.py
+++ b/blacksmith/experiments/torch/llama/xla/train.py
@@ -143,18 +143,18 @@ def train(
     global_step = 0
 
     try:
-        # Initial validation
-        model.eval()
-        val_loss = validate(
-            eval_model,
-            eval_dataloader,
-            cross_entropy_loss,
-            logger,
-            device_manager.device,
-            config,
-            tokenizer,
-        )
-        logger.log_metrics({"val/loss": val_loss}, commit=True, step=global_step)
+        # # Initial validation
+        # model.eval()
+        # val_loss = validate(
+        #     eval_model,
+        #     eval_dataloader,
+        #     cross_entropy_loss,
+        #     logger,
+        #     device_manager.device,
+        #     config,
+        #     tokenizer,
+        # )
+        # logger.log_metrics({"val/loss": val_loss}, commit=True, step=global_step)
         model.train()
 
         # TODO: Refactor when https://github.com/tenstorrent/tt-blacksmith/issues/602#issue-4596214372 is resolved.
@@ -166,6 +166,7 @@ def train(
         for epoch in range(config.num_epochs):
             accumulation_step = 0
             running_loss = 0.0
+            step_loss = None
 
             for batch in tqdm(train_dataloader, desc="Training"):
                 # Zero out gradients at the start of accumulation cycle
@@ -192,20 +193,20 @@ def train(
                 loss_ = compute_loss_fn(batch, model, cross_entropy_loss, config.gradient_accumulation_steps)
                 loss_.backward()
 
-                if config.use_tt:
-                    tensors_to_sync = [loss_] + [p.grad for p in trainable_params if p.grad is not None]
-                    devices = list({t.device.type for t in tensors_to_sync})
-                    torch_xla._XLAC._xla_sync_multi(tensors_to_sync, devices, wait=True)
-                    # Optimizer will do unnecessary recompute if we don't clear the pending IRs after syncing the loss and grads.
-                    torch_xla._XLAC._clear_pending_irs(torch_xla._XLAC._xla_get_default_device())
-
-                running_loss += loss_.item()
+                # Keep the whole step (forward + backward + optimizer) in a single graph.
+                # No sync is issued here on purpose: the forward and backward IR stays pending
+                # and lazily joins the optimizer update, so everything is compiled and executed
+                # together by the one sync inside `optimizer_step`. The detached micro-batch loss
+                # is accumulated lazily so it can be read afterwards without cutting the graph.
+                step_loss = loss_.detach() if step_loss is None else step_loss + loss_.detach()
                 accumulation_step += 1
 
                 # Only step the optimizer after accumulating gradients.
                 if accumulation_step == config.gradient_accumulation_steps:
                     device_manager.optimizer_step(optimizer)
 
+                    running_loss += step_loss.item()
+                    step_loss = None
                     accumulation_step = 0
                     global_step += 1
 

--- a/blacksmith/experiments/torch/llama/xla/train.py
+++ b/blacksmith/experiments/torch/llama/xla/train.py
@@ -143,18 +143,18 @@ def train(
     global_step = 0
 
     try:
-        # # Initial validation
-        # model.eval()
-        # val_loss = validate(
-        #     eval_model,
-        #     eval_dataloader,
-        #     cross_entropy_loss,
-        #     logger,
-        #     device_manager.device,
-        #     config,
-        #     tokenizer,
-        # )
-        # logger.log_metrics({"val/loss": val_loss}, commit=True, step=global_step)
+        # Initial validation
+        model.eval()
+        val_loss = validate(
+            eval_model,
+            eval_dataloader,
+            cross_entropy_loss,
+            logger,
+            device_manager.device,
+            config,
+            tokenizer,
+        )
+        logger.log_metrics({"val/loss": val_loss}, commit=True, step=global_step)
         model.train()
 
         # TODO: Refactor when https://github.com/tenstorrent/tt-blacksmith/issues/602#issue-4596214372 is resolved.
@@ -193,13 +193,12 @@ def train(
                 loss_ = compute_loss_fn(batch, model, cross_entropy_loss, config.gradient_accumulation_steps)
                 loss_.backward()
 
-                # Keep the whole step (forward + backward + optimizer) in a single graph.
-                # No sync is issued here on purpose: the forward and backward IR stays pending
-                # and lazily joins the optimizer update, so everything is compiled and executed
-                # together by the one sync inside `optimizer_step`. The detached micro-batch loss
-                # is accumulated lazily so it can be read afterwards without cutting the graph.
-                step_loss = loss_.detach() if step_loss is None else step_loss + loss_.detach()
-                accumulation_step += 1
+                if config.use_tt:
+                    tensors_to_sync = [loss_] + [p.grad for p in trainable_params if p.grad is not None]
+                    devices = list({t.device.type for t in tensors_to_sync})
+                    torch_xla._XLAC._xla_sync_multi(tensors_to_sync, devices, wait=True)
+                    # Optimizer will do unnecessary recompute if we don't clear the pending IRs after syncing the loss and grads.
+                    torch_xla._XLAC._clear_pending_irs(torch_xla._XLAC._xla_get_default_device())
 
                 # Only step the optimizer after accumulating gradients.
                 if accumulation_step == config.gradient_accumulation_steps:

--- a/blacksmith/experiments/torch/llama/xla/train.py
+++ b/blacksmith/experiments/torch/llama/xla/train.py
@@ -199,7 +199,7 @@ def train(
                     torch_xla._XLAC._xla_sync_multi(tensors_to_sync, devices, wait=True)
                     # Optimizer will do unnecessary recompute if we don't clear the pending IRs after syncing the loss and grads.
                     torch_xla._XLAC._clear_pending_irs(torch_xla._XLAC._xla_get_default_device())
-                
+
                 running_loss += loss_.item()
                 accumulation_step += 1
 

--- a/blacksmith/tools/templates/configs.py
+++ b/blacksmith/tools/templates/configs.py
@@ -84,7 +84,7 @@ class TrainingConfig(BaseModel):
     enable_trace: bool = Field(default=False)
     trace_region_size: int = Field(default=1000000000, gt=0)  # DRAM region size (bytes) for runtime trace
     enable_const_eval: bool = Field(default=False)
-    
+
     def torch_dtype(self) -> torch.dtype:
         # Broader than TrainerConfig: some experiment YAMLs still use float16.
         dtypes = {
@@ -96,4 +96,3 @@ class TrainingConfig(BaseModel):
             return dtypes[self.dtype]
         except KeyError as e:
             raise ValueError(f"Unsupported dtype {self.dtype!r}; expected one of {sorted(dtypes)}") from e
-

--- a/blacksmith/tools/templates/configs.py
+++ b/blacksmith/tools/templates/configs.py
@@ -83,7 +83,7 @@ class TrainingConfig(BaseModel):
     use_tt: bool = Field(default=True)
     enable_trace: bool = Field(default=False)
     trace_region_size: int = Field(default=1000000000, gt=0)  # DRAM region size (bytes) for runtime trace
-    enable_const_eval: bool = Field(default=False)
+    enable_const_eval: bool = Field(default=True)
 
     def torch_dtype(self) -> torch.dtype:
         # Broader than TrainerConfig: some experiment YAMLs still use float16.

--- a/blacksmith/tools/templates/configs.py
+++ b/blacksmith/tools/templates/configs.py
@@ -83,7 +83,8 @@ class TrainingConfig(BaseModel):
     use_tt: bool = Field(default=True)
     enable_trace: bool = Field(default=False)
     trace_region_size: int = Field(default=1000000000, gt=0)  # DRAM region size (bytes) for runtime trace
-
+    enable_const_eval: bool = Field(default=False)
+    
     def torch_dtype(self) -> torch.dtype:
         # Broader than TrainerConfig: some experiment YAMLs still use float16.
         dtypes = {
@@ -95,3 +96,4 @@ class TrainingConfig(BaseModel):
             return dtypes[self.dtype]
         except KeyError as e:
             raise ValueError(f"Unsupported dtype {self.dtype!r}; expected one of {sorted(dtypes)}") from e
+


### PR DESCRIPTION
### Issue

N/A

### Problem description

By default const-eval is enabled in tt-blacksmith. During compilation this folds every subgraph whose inputs are graph constants (weight-preprocessing: bf16 - f32 casts, RMSNorm / LoRA weight prep) into CPU-hoisted functions. 
In the compiled IR for LLama 3.1 8B that produces 350 `main_const_eval_*` functions and 270 `ttir.cpu_hoist_call`s into 33 `cpu_hoisted_const_eval_*` CPU functions.

This PR exposes an `enable_const_eval` compile option (default `True`) and sets it to `False` for the LLaMA 3.1 8B single-chip LoRA config, keeping those ops on-device.

### Perf improvement (LLaMA 3.1 8B, BS=1, SEQ=512, single chip)

| Old (const-eval on) | New (const-eval off) | Improvement |
| ------------------- | -------------------- | ----------- |
| 4959s              | 1448s               | 29.2%       |

### What's Changed

- Add `enable_const_eval: bool = True` to `TrainingConfig` (`experiments/torch/llama/configs.py` and `tools/templates/configs.py`).
- Forward `enable_const_eval` into `torch_xla.set_custom_compile_options` in `experiments/torch/llama/xla/train.py`.
- Set `enable_const_eval: False` in `xla/lora/single_chip/llama_3_1_8b_sst2.yaml`.

### Notes

- Default behavior is unchanged (`enable_const_eval=True`); only Llama 8B single-chip LoRA config opts out.
- The same yaml also sets `max_length: 512` and `batch_size: 1` to match the BS=1/SEQ=512 configuration used for these PERF measurements.
