### PR TITLE
Experiment Table Cleanup

### DIFF
--- a/blacksmith/experiments/jax/distil_bert/README.md
+++ b/blacksmith/experiments/jax/distil_bert/README.md
@@ -49,6 +49,11 @@ Source: [Hugging Face Dataset Hub](https://huggingface.co/datasets/glue/viewer/s
 
 ## Configuration
 
+| Architecture       | mesh_shape                   | mesh_axis_names      | dataset      | Method     |
+| ------------------ | ---------------------------- | -------------------- | ------------ | ---------- |
+| [Single-Chip](distil_bert_sst2.yaml) | None                         | None   | SST-2 | Distillation     |
+| [N300](distil_bert_sst2.yaml) | '[2]'                         | "data"   | SST-2 | Distillation, data parallel     |
+
 The experiment parameters are defined in `distil_bert_sst2.yaml`.
 This configuration specifies dataset, model settings, training hyperparameters, and loss weighting used during distillation.
 

--- a/blacksmith/experiments/jax/llama/dora/README.md
+++ b/blacksmith/experiments/jax/llama/dora/README.md
@@ -19,6 +19,12 @@ pip install git+https://github.com/patrick-kidger/equinox.git@367124071570194b5d
 pip install plum-dispatch==2.5.7 beartype==0.21.0 rich==14.1.0
 ```
 
+### Configuration
+ 
+| Architecture       | mesh_shape                   | mesh_axis_names      | dataset      | Method                      |
+| ------------------ | ---------------------------- | -------------------- | ------------ | --------------------------- |
+| [Single-Chip](llama_sst2.yaml) | None                      | None        | SST-2 | DoRA     |
+
 ### TT Device Training
 
 Run DoRA training on Tenstorrent device:

--- a/blacksmith/experiments/jax/llama/dora/README.md
+++ b/blacksmith/experiments/jax/llama/dora/README.md
@@ -20,7 +20,7 @@ pip install plum-dispatch==2.5.7 beartype==0.21.0 rich==14.1.0
 ```
 
 ### Configuration
- 
+
 | Architecture       | mesh_shape                   | mesh_axis_names      | dataset      | Method                      |
 | ------------------ | ---------------------------- | -------------------- | ------------ | --------------------------- |
 | [Single-Chip](llama_sst2.yaml) | None                      | None        | SST-2 | DoRA     |

--- a/blacksmith/experiments/jax/llama/lora/README.md
+++ b/blacksmith/experiments/jax/llama/lora/README.md
@@ -21,6 +21,12 @@ pip install plum-dispatch==2.5.7 beartype==0.21.0 rich==14.1.0
 
 ## Usage
 
+### Configuration
+
+| Architecture       | mesh_shape                   | mesh_axis_names      | dataset      | Method                      |
+| ------------------ | ---------------------------- | -------------------- | ------------ | --------------------------- |
+| [Single-Chip](llama_sst2.yaml) | None                         | None     | SST-2 | LoRA     |
+
 ### TT Device Training
 
 Run LoRA training on Tenstorrent device:

--- a/blacksmith/experiments/jax/mnist/README.md
+++ b/blacksmith/experiments/jax/mnist/README.md
@@ -3,6 +3,12 @@
 This directory contains the code in JAX (and in Flax) for training multilayer perceptron (MLP) on MNIST dataset, through Tenstorrent's Forge compiler with logging to [Weights&Biases](https://wandb.ai/site/).
 The connection to the Tenstorrent device is established in script ```blacksmith/tools/jax_utils.py```. For more details on connecting to Tenstorrent's hardware in JAX, please refer to [tt-xla](https://github.com/tenstorrent/tt-xla).
 ## Training
+| Architecture       | mesh_shape                   | mesh_axis_names      | dataset      | Method     |
+| ------------------ | ---------------------------- | -------------------- | ------------ | ---------- |
+| [Single-Chip](mnist.yaml) | None               | None      | MNIST         | Full Model       |
+| [N300](mnist.yaml) | `[2]`                     | `["dp"]`  | MNIST        | Full Model, Data Parallel       |
+| [N300](mnist.yaml) | `[2]`                     | `["tp"]`  | MNIST        | Full Model, Tensor Parallel   |
+
 To run the single chip training script in JAX, run the command
 ```
 python3 blacksmith/experiments/jax/mnist/single_chip/train.py

--- a/blacksmith/experiments/jax/mnist/README.md
+++ b/blacksmith/experiments/jax/mnist/README.md
@@ -6,8 +6,8 @@ The connection to the Tenstorrent device is established in script ```blacksmith/
 | Architecture       | mesh_shape                   | mesh_axis_names      | dataset      | Method     |
 | ------------------ | ---------------------------- | -------------------- | ------------ | ---------- |
 | [Single-Chip](mnist.yaml) | None               | None      | MNIST         | Full Model       |
-| [N300](mnist.yaml) | `[2]`                     | `["dp"]`  | MNIST        | Full Model, Data Parallel       |
-| [N300](mnist.yaml) | `[2]`                     | `["tp"]`  | MNIST        | Full Model, Tensor Parallel   |
+| [N300](mnist.yaml) | `[2]`                     | `"dp"`  | MNIST        | Full Model, Data Parallel       |
+| [N300](mnist.yaml) | `[2]`                     | `"tp"`  | MNIST        | Full Model, Tensor Parallel   |
 
 To run the single chip training script in JAX, run the command
 ```

--- a/blacksmith/experiments/jax/nerf/README.md
+++ b/blacksmith/experiments/jax/nerf/README.md
@@ -43,6 +43,10 @@ Check the dataset documentation mentioned above for more information.
 
 ## Configuration
 
+| Architecture       | mesh_shape                   | mesh_axis_names      | dataset      | Method                      |
+| ------------------ | ---------------------------- | -------------------- | ------------ | --------------------------- |
+| [Single-Chip](nerf_blender.yaml) | None                         | None   | Blender  | Full Model     |
+
 The experiment is configured using the configuration file `nerf_blender.yaml`. The configuration file specifies the hyperparameters for the experiment, such as the number of epochs, the batch size, and the learning rate.
 
 Current `nerf_blender.yaml` has the recommended and tested hyperparameters for the experiment.

--- a/blacksmith/experiments/lightning/nerf/README.md
+++ b/blacksmith/experiments/lightning/nerf/README.md
@@ -41,6 +41,10 @@ Check the dataset documentation mentioned above for more information.
 
 ## Configuration
 
+| Architecture       | mesh_shape                   | mesh_axis_names      | dataset      | Method     |
+| ------------------ | ---------------------------- | -------------------- | ------------ | ---------- |
+| [Single-Chip](nerf.yaml) | None                   | None                 | Blender      | Full Model |
+
 The experiment is configured using the configuration file `nerf.yaml`. The configuration file specifies the hyperparameters for the experiment, such as the number of epochs, the batch size, and the learning rate.
 
 Current `nerf.yaml` has the recommended and tested hyperparameters for the experiment.

--- a/blacksmith/experiments/torch/BOUNTIES/gatv2_pubmed/README.md
+++ b/blacksmith/experiments/torch/BOUNTIES/gatv2_pubmed/README.md
@@ -58,6 +58,12 @@ A golden-loss regression case (`tt-gatv2_pubmed-pubmed-n150`, config under
 `tests/configs/BOUNTIES/`) is defined in `tests/training_test_cases.py` but kept
 commented out until the experiment dependency and a TT runner are wired into CI.
 
+## Configuration
+
+| Architecture       | mesh_shape                   | mesh_axis_names      | input_sharding_dim | dataset      | Method                      |
+| ------------------ | ---------------------------- | -------------------- | ------------------ | ------------ | --------------------------- |
+| [Single-Chip](single_chip/gatv2_pubmed_tt.yaml) | None        | None        | None         | PubMed      | Full Model |
+
 ## Configuration Parameters
 
 | Parameter | Description | Default Value |

--- a/blacksmith/experiments/torch/albert/README.md
+++ b/blacksmith/experiments/torch/albert/README.md
@@ -31,6 +31,10 @@ Example
 
 ## Configuration
 
+| Architecture       | mesh_shape                   | mesh_axis_names      | input_sharding_dim | dataset      | Method                      |
+| ------------------ | ---------------------------- | -------------------- | ------------------ | ------------ | --------------------------- |
+| [Single-Chip](single_chip/albert_banking77.yaml) | None        | None    | None    | Banking77    | Adapters   |
+
 The experiment is configured using the configuration file `albert_banking77.yaml`. The configuration file specifies the hyperparameters for the experiment, such as the number of epochs, the batch size, and the lora configuration.
 
 Current `albert_banking77.yaml` has the recommended and tested hyperparameters for the experiment.

--- a/blacksmith/experiments/torch/gemma/README.md
+++ b/blacksmith/experiments/torch/gemma/README.md
@@ -36,6 +36,10 @@ Example:
 
 ## Configuration
 
+| Architecture       | mesh_shape                   | mesh_axis_names      | input_sharding_dim | dataset      | Method                      |
+| ------------------ | ---------------------------- | -------------------- | ------------------ | ------------ | --------------------------- |
+| [Single-Chip](single_chip/gemma_sst2.yaml) | None        | None          | None           | SST-2        | LoRA      |
+
 The experiment is configured using the configuration file `gemma_sst2.yaml`. The configuration file specifies the hyperparameters for the experiment, such as the number of epochs, the batch size, and the lora configuration.
 
 Current `gemma_sst2.yaml` has the recommended and tested hyperparameters for the experiment.

--- a/blacksmith/experiments/torch/gemma11/dpo/README.md
+++ b/blacksmith/experiments/torch/gemma11/dpo/README.md
@@ -34,9 +34,9 @@ python3 blacksmith/experiments/torch/gemma11/dpo/train.py --config blacksmith/ex
 
 #### Training Configuration
 
-| Architecture | mesh_shape | mesh_axis_names | dataset | Method |
-| ------------ | ---------- | --------------- | ------- | ------ |
-| [P150](single_chip/gemma11_math_preferences_dpo.yaml) | None | None | Math Preference (DPO) | DPO + LoRA |
+| Architecture       | mesh_shape                   | mesh_axis_names      | input_sharding_dim | dataset      | Method                      |
+| ------------------ | ---------------------------- | -------------------- | ------------------ | ------------ | --------------------------- |
+| [P150](single_chip/gemma11_math_preferences_dpo.yaml) | None | None | None | Math Preference (DPO) | DPO + LoRA |
 
 ## Data
 

--- a/blacksmith/experiments/torch/gemma11/lora/README.md
+++ b/blacksmith/experiments/torch/gemma11/lora/README.md
@@ -35,11 +35,11 @@ python3 blacksmith/experiments/torch/gemma11/lora/train.py --config blacksmith/e
 
 #### Training Configurations
 
-| Architecture | mesh_shape | mesh_axis_names | dataset | Method |
-| ------------ | ---------- | --------------- | ------- | ------ |
-| [Single-Chip](single_chip/gemma11_sst2.yaml) | None | None | SST2 | LoRA |
-| [Single-Chip](single_chip/gemma11_squadV2.yaml) | None | None | SQuAD V2 | LoRA |
-| [P150](single_chip/gemma11_math_preferences_sft.yaml) | None | None | Math Preference (SFT) | LoRA |
+| Architecture       | mesh_shape                   | mesh_axis_names      | input_sharding_dim | dataset      | Method                      |
+| ------------------ | ---------------------------- | -------------------- | ------------------ | ------------ | --------------------------- |
+| [Single-Chip](single_chip/gemma11_sst2.yaml) | None | None | None | SST2 | LoRA |
+| [Single-Chip](single_chip/gemma11_squadV2.yaml) | None | None | None | SQuAD V2 | LoRA |
+| [P150](single_chip/gemma11_math_preferences_sft.yaml) | None | None | None | Math Preference (SFT) | LoRA |
 
 ## Data
 

--- a/blacksmith/experiments/torch/gemma4/README.md
+++ b/blacksmith/experiments/torch/gemma4/README.md
@@ -70,9 +70,9 @@ python3 blacksmith/experiments/torch/gemma4/train.py --config blacksmith/experim
 
 #### Gemma 4 E2B Training Configurations
 
-| Architecture | mesh_shape | mesh_axis_names | Dataset | Method |
-| --- | --- | --- | --- | --- |
-| [BH LoudBox](lora/loudbox/gemma4_e2b_wizardlm.yaml) | `[1, 8]` | `["batch", "model"]` | WizardLM-Evol | LoRA |
+| Architecture | mesh_shape | mesh_axis_names | input_sharding_dim | Dataset | Method |
+| --- | --- | --- | --- | --- | --- |
+| [BH LoudBox](lora/loudbox/gemma4_e2b_wizardlm.yaml) | `[1, 8]` | `["batch", "model"]` | None | WizardLM-Evol | LoRA |
 
 ## Data
 

--- a/blacksmith/experiments/torch/gpt_oss/README.md
+++ b/blacksmith/experiments/torch/gpt_oss/README.md
@@ -64,10 +64,10 @@ python3 blacksmith/experiments/torch/gpt_oss/train.py --config blacksmith/experi
 
 #### GPT-OSS 20B Training Configurations
 
-| Architecture | mesh_shape | mesh_axis_names | Dataset | Method |
-| --- | --- | --- | --- | --- |
-| [BH LoudBox](lora/loudbox/gpt_oss_20b_sst2.yaml) | `[1, 8]` | `["batch", "model"]` | SST-2 | LoRA |
-| [WH Galaxy](lora/galaxy/gpt_oss_20b_alpaca.yaml) | `[4, 8]` | `["batch", "model"]` | Alpaca | LoRA |
+| Architecture       | mesh_shape                   | mesh_axis_names      | input_sharding_dim | dataset      | Method                      |
+| ------------------ | ---------------------------- | -------------------- | ------------------ | ------------ | --------------------------- |
+| [BH LoudBox](lora/loudbox/gpt_oss_20b_sst2.yaml) | `[1, 8]` | `["batch", "model"]` |None    | SST-2 | LoRA |
+| [WH Galaxy](lora/galaxy/gpt_oss_20b_alpaca.yaml) | `[4, 8]` | `["batch", "model"]` |None    | Alpaca | LoRA |
 
 
 ### GPT-OSS 120B Training
@@ -79,9 +79,9 @@ python3 blacksmith/experiments/torch/gpt_oss/train.py --config blacksmith/experi
 
 #### GPT-OSS 20B Training Configurations
 
-| Architecture | mesh_shape | mesh_axis_names | Dataset | Method |
-| --- | --- | --- | --- | --- |
-| [WH Galaxy](lora/galaxy/gpt_oss_120b_alpaca.yaml) | `[4, 8]` | `["batch", "model"]` | Alpaca | LoRA |
+| Architecture       | mesh_shape                   | mesh_axis_names      | input_sharding_dim | dataset      | Method                      |
+| ------------------ | ---------------------------- | -------------------- | ------------------ | ------------ | --------------------------- |
+| [WH Galaxy](lora/galaxy/gpt_oss_120b_alpaca.yaml) | `[4, 8]` | `["batch", "model"]` |None    | Alpaca | LoRA |
 
 ## Data
 

--- a/blacksmith/experiments/torch/llama/xla/adapters/README.md
+++ b/blacksmith/experiments/torch/llama/xla/adapters/README.md
@@ -37,6 +37,11 @@ Example
 
 ## Configuration
 
+| Architecture       | mesh_shape                   | mesh_axis_names      | input_sharding_dim | dataset      | Method                      |
+| ------------------ | ---------------------------- | -------------------- | ------------------ | ------------ | --------------------------- |
+| [Single-Chip](single_chip/llama_3_2_1b_sst2.yaml) | None     | None      | None               |   SST2       | Adapters   |
+
+
 The experiment is configured using the configuration file `llama_3_2_1b_sst2.yaml`. The configuration file specifies the hyperparameters for the experiment, such as the number of epochs, the batch size, and the lora configuration.
 
 Current `llama_3_2_1b_sst2.yaml` has the recommended and tested hyperparameters for the experiment.

--- a/blacksmith/experiments/torch/llama/xla/lora/README.md
+++ b/blacksmith/experiments/torch/llama/xla/lora/README.md
@@ -70,10 +70,10 @@ python3 blacksmith/experiments/torch/llama/xla/train.py --config blacksmith/expe
 | ------------------ | ---------------------------- | -------------------- | ------------------ | ------------ | --------------------------- |
 | [Single-Chip](single_chip/llama_3_2_1b_alpaca.yaml) | None          | None            | None                     | Alpaca  | LoRA   |
 | [Single-Chip](single_chip/llama_3_2_1b_sst2.yaml) | None                         | None        | None                      | SST2    | LoRA   |
-| [N300](quietbox/llama_3_2_1b_sst2.yaml) | `[1, 2]`, `[2, 1]`           | `["data", "model"]`, `["model", "data"]` | `"batch"`  | SST2    | LoRA   |
-| [Wormhole QuietBox](quietbox/llama_3_2_1b_sst2.yaml) | `[1, 8]`, `[8, 1]`, `[2, 4]` | `["data", "model"]`, `["model", "data"]` | `"batch"`   | SST2    | LoRA   |
-| [Blackhole QuietBox](quietbox/llama_3_2_1b_sst2.yaml) | `[1, 4]`                     | `["data", "model"]`     | `"batch"`              | SST2    | LoRA   |
-| [Galaxy](galaxy/llama_3_2_1b_sst2.yaml) | `[8, 4]`                     | `["data", "model"]`, `["model", "data"]`| `"batch"`   | SST2    | LoRA   |
+| [N300](quietbox/llama_3_2_1b_sst2.yaml) | `[1, 2]`, `[2, 1]`           | `["batch", "model"]`, `["model", "batch"]` | `"batch"`  | SST2    | LoRA   |
+| [Wormhole QuietBox](quietbox/llama_3_2_1b_sst2.yaml) | `[1, 8]`, `[8, 1]`, `[2, 4]` | `["batch", "model"]`, `["model", "batch"]` | `"batch"`   | SST2    | LoRA   |
+| [Blackhole QuietBox](quietbox/llama_3_2_1b_sst2.yaml) | `[1, 4]`                     | `["batch", "model"]`     | `"batch"`              | SST2    | LoRA   |
+| [Galaxy](galaxy/llama_3_2_1b_sst2.yaml) | `[8, 4]`                     | `["batch", "model"]`, `["model", "batch"]`| `"batch"`   | SST2    | LoRA   |
 
 ### Llama 3.2 3B Training
 
@@ -95,7 +95,7 @@ python3 blacksmith/experiments/torch/llama/xla/train.py --config blacksmith/expe
 | Architecture       | mesh_shape                   | mesh_axis_names      | input_sharding_dim | dataset      | Method                      |
 | ------------------ | ---------------------------- | -------------------- | ------------------ | ------------ | --------------------------- |
 | [P150](single_chip/llama_3_2_3b_fusechat.yaml) | None                         | None          | None                   | FuseChat  | LoRA   |
-| [Blackhole QuietBox](quietbox/llama_3_2_3b_fusechat.yaml) | `[1, 4]`          | `["data", "model"]`  | None      | FuseChat         | LoRA       |
+| [Blackhole QuietBox](quietbox/llama_3_2_3b_fusechat.yaml) | `[1, 4]`          | `["batch", "model"]`  | None      | FuseChat         | LoRA       |
 
 ### Llama 3.1 8B Training
 
@@ -124,11 +124,11 @@ python3 blacksmith/experiments/torch/llama/xla/train.py --config blacksmith/expe
 | Architecture       | mesh_shape                   | mesh_axis_names      | input_sharding_dim | dataset      | Method                      |
 | ------------------ | ---------------------------- | -------------------- | ------------------ | ------------ | --------------------------- |
 | [P150](single_chip/llama_3_1_8b_sst2.yaml)           | None     | None                            | None            | SST2    | LoRA   |
-| [Wormhole QuietBox](quietbox/llama_3_1_8b_sst2.yaml) | `[1, 8]`   | `["data", "model"]`           | `["batch"]`     | SST2    | LoRA   |
-| [Wormhole QuietBox](quietbox/llama_3_1_8b_sst2.yaml) | `[8, 1]`   | `["model", "data"]`           | `["batch"]`     | SST2    | LoRA   |
-| [Wormhole QuietBox](quietbox/llama_3_1_8b_sst2.yaml) | `[2, 4]`   | `["data", "model"]`           | `["batch"]`     | SST2    | LoRA   |
-| [Blackhole QuietBox](quietbox/llama_3_1_8b_sst2.yaml) | `[1, 4]`   | `["data", "model"]`          | `["batch"]`     | SST2    | LoRA   |
-| [Galaxy](galaxy/llama_3_1_8b_sst2.yaml) | `[8, 4]`   | `["data", "model"]`, `["model", "data"]`   | `["batch"]`     | SST2    | LoRA   |
+| [Wormhole QuietBox](quietbox/llama_3_1_8b_sst2.yaml) | `[1, 8]`   | `["batch", "model"]`           | `"batch"`     | SST2    | LoRA   |
+| [Wormhole QuietBox](quietbox/llama_3_1_8b_sst2.yaml) | `[8, 1]`   | `["model", "batch"]`           | `"batch"`     | SST2    | LoRA   |
+| [Wormhole QuietBox](quietbox/llama_3_1_8b_sst2.yaml) | `[2, 4]`   | `["batch", "model"]`           | `"batch"`     | SST2    | LoRA   |
+| [Blackhole QuietBox](quietbox/llama_3_1_8b_sst2.yaml) | `[1, 4]`   | `["batch", "model"]`          | `"batch"`     | SST2    | LoRA   |
+| [Galaxy](galaxy/llama_3_1_8b_sst2.yaml) | `[8, 4]`   | `["batch", "model"]`, `["model", "batch"]`  | `"batch"`     | SST2    | LoRA   |
 
 ### Llama 3.1 8B Instruct Training
 
@@ -141,7 +141,7 @@ python3 blacksmith/experiments/torch/llama/xla/train.py --config blacksmith/expe
 
 | Architecture       | mesh_shape                   | mesh_axis_names      | input_sharding_dim | dataset      | Method                      |
 | ------------------ | ---------------------------- | -------------------- | ------------------ | ------------ | --------------------------- |
-| [Wormhole QuietBox](quietbox/llama_3_1_8b_instruct_metamathqa.yaml) | `[2, 4]`   | `["data", "model"]`  | `["data"]`  | MetaMathQA    | LoRA   |
+| [Wormhole QuietBox](quietbox/llama_3_1_8b_instruct_metamathqa.yaml) | `[2, 4]`   | `["data", "model"]`  | `"data"`  | MetaMathQA    | LoRA   |
 
 
 ### Llama 3.1 70B Training

--- a/blacksmith/experiments/torch/llama/xla/lora/README.md
+++ b/blacksmith/experiments/torch/llama/xla/lora/README.md
@@ -66,14 +66,14 @@ python3 blacksmith/experiments/torch/llama/xla/train.py --config blacksmith/expe
 
 #### Llama 3.2 1B Training Configurations
 
-| Architecture       | mesh_shape                   | mesh_axis_names                          | dataset | Method |
-| ------------------ | ---------------------------- | ---------------------------------------- | ------- | ------ |
-| [Single-Chip](single_chip/llama_3_2_1b_alpaca.yaml) | None                         | None                                     | Alpaca  | LoRA   |
-| [Single-Chip](single_chip/llama_3_2_1b_sst2.yaml) | None                         | None                                     | SST2    | LoRA   |
-| [N300](quietbox/llama_3_2_1b_sst2.yaml) | `[1, 2]`, `[2, 1]`           | `["data", "model"]`, `["model", "data"]` | SST2    | LoRA   |
-| [Wormhole QuietBox](quietbox/llama_3_2_1b_sst2.yaml) | `[1, 8]`, `[8, 1]`, `[2, 4]` | `["data", "model"]`, `["model", "data"]` | SST2    | LoRA   |
-| [Blackhole QuietBox](quietbox/llama_3_2_1b_sst2.yaml) | `[1, 4]`                     | `["data", "model"]`                      | SST2    | LoRA   |
-| [Galaxy](galaxy/llama_3_2_1b_sst2.yaml) | `[8, 4]`                     | `["data", "model"]`, `["model", "data"]` | SST2    | LoRA   |
+| Architecture       | mesh_shape                   | mesh_axis_names      | input_sharding_dim | dataset      | Method                      |
+| ------------------ | ---------------------------- | -------------------- | ------------------ | ------------ | --------------------------- |
+| [Single-Chip](single_chip/llama_3_2_1b_alpaca.yaml) | None          | None            | None                     | Alpaca  | LoRA   |
+| [Single-Chip](single_chip/llama_3_2_1b_sst2.yaml) | None                         | None        | None                      | SST2    | LoRA   |
+| [N300](quietbox/llama_3_2_1b_sst2.yaml) | `[1, 2]`, `[2, 1]`           | `["data", "model"]`, `["model", "data"]` | `["batch"]`  | SST2    | LoRA   |
+| [Wormhole QuietBox](quietbox/llama_3_2_1b_sst2.yaml) | `[1, 8]`, `[8, 1]`, `[2, 4]` | `["data", "model"]`, `["model", "data"]` | `["batch"]`   | SST2    | LoRA   |
+| [Blackhole QuietBox](quietbox/llama_3_2_1b_sst2.yaml) | `[1, 4]`                     | `["data", "model"]`     | `["batch"]`            | SST2    | LoRA   |
+| [Galaxy](galaxy/llama_3_2_1b_sst2.yaml) | `[8, 4]`                     | `["data", "model"]`, `["model", "data"]`| `["batch"]`   | SST2    | LoRA   |
 
 ### Llama 3.2 3B Training
 
@@ -92,10 +92,10 @@ python3 blacksmith/experiments/torch/llama/xla/train.py --config blacksmith/expe
 
 #### Llama 3.2 3B Training Configuration
 
-| Architecture       | mesh_shape                   | mesh_axis_names      | dataset      | Method     |
-| ------------------ | ---------------------------- | -------------------- | ------------ | ---------- |
-| [P150](single_chip/llama_3_2_3b_fusechat.yaml) | None                         | None                                     | FuseChat  | LoRA   |
-| [Blackhole QuietBox](quietbox/llama_3_2_3b_fusechat.yaml) | `[1, 4]`                     | `["data", "model"]`  | FuseChat         | LoRA       |
+| Architecture       | mesh_shape                   | mesh_axis_names      | input_sharding_dim | dataset      | Method                      |
+| ------------------ | ---------------------------- | -------------------- | ------------------ | ------------ | --------------------------- |
+| [P150](single_chip/llama_3_2_3b_fusechat.yaml) | None                         | None          | None                   | FuseChat  | LoRA   |
+| [Blackhole QuietBox](quietbox/llama_3_2_3b_fusechat.yaml) | `[1, 4]`          | `["data", "model"]`  | None      | FuseChat         | LoRA       |
 
 ### Llama 3.1 8B Training
 
@@ -121,14 +121,14 @@ python3 blacksmith/experiments/torch/llama/xla/train.py --config blacksmith/expe
 
 #### Llama 3.1 8B Training Configurations
 
-| Architecture       | mesh_shape | mesh_axis_names                          | dataset | Method |
-| ------------------ | ---------- | ---------------------------------------- | ------- | ------ |
-| [P150](single_chip/llama_3_1_8b_sst2.yaml) | None     | None            | SST2  | LoRA   |
-| [Wormhole QuietBox](quietbox/llama_3_1_8b_sst2.yaml) | `[1, 8]`   | `["data", "model"]`                      | SST2    | LoRA   |
-| [Wormhole QuietBox](quietbox/llama_3_1_8b_sst2.yaml) | `[8, 1]`   | `["model", "data"]`                      | SST2    | LoRA   |
-| [Wormhole QuietBox](quietbox/llama_3_1_8b_sst2.yaml) | `[2, 4]`   | `["data", "model"]`                      | SST2    | LoRA   |
-| [Blackhole QuietBox](quietbox/llama_3_1_8b_sst2.yaml) | `[1, 4]`   | `["data", "model"]`                      | SST2    | LoRA   |
-| [Galaxy](galaxy/llama_3_1_8b_sst2.yaml) | `[8, 4]`   | `["data", "model"]`, `["model", "data"]` | SST2    | LoRA   |
+| Architecture       | mesh_shape                   | mesh_axis_names      | input_sharding_dim | dataset      | Method                      |
+| ------------------ | ---------------------------- | -------------------- | ------------------ | ------------ | --------------------------- |
+| [P150](single_chip/llama_3_1_8b_sst2.yaml)           | None     | None                            | None            | SST2    | LoRA   |
+| [Wormhole QuietBox](quietbox/llama_3_1_8b_sst2.yaml) | `[1, 8]`   | `["data", "model"]`           | `["batch"]`     | SST2    | LoRA   |
+| [Wormhole QuietBox](quietbox/llama_3_1_8b_sst2.yaml) | `[8, 1]`   | `["model", "data"]`           | `["batch"]`     | SST2    | LoRA   |
+| [Wormhole QuietBox](quietbox/llama_3_1_8b_sst2.yaml) | `[2, 4]`   | `["data", "model"]`           | `["batch"]`     | SST2    | LoRA   |
+| [Blackhole QuietBox](quietbox/llama_3_1_8b_sst2.yaml) | `[1, 4]`   | `["data", "model"]`          | `["batch"]`     | SST2    | LoRA   |
+| [Galaxy](galaxy/llama_3_1_8b_sst2.yaml) | `[8, 4]`   | `["data", "model"]`, `["model", "data"]`   | `["batch"]`     | SST2    | LoRA   |
 
 ### Llama 3.1 8B Instruct Training
 
@@ -139,9 +139,9 @@ python3 blacksmith/experiments/torch/llama/xla/train.py --config blacksmith/expe
 
 #### Llama 3.3 8B Instruct Training Configurations
 
-| Architecture       | mesh_shape | mesh_axis_names                          | dataset | Method |
-| ------------------ | ---------- | ---------------------------------------- | ------- | ------ |
-| [Wormhole QuietBox](quietbox/llama_3_1_8b_instruct_metamathqa.yaml) | `[2, 4]`   | `["data", "model"]`                      | MetaMathQA    | LoRA   |
+| Architecture       | mesh_shape                   | mesh_axis_names      | input_sharding_dim | dataset      | Method                      |
+| ------------------ | ---------------------------- | -------------------- | ------------------ | ------------ | --------------------------- |
+| [Wormhole QuietBox](quietbox/llama_3_1_8b_instruct_metamathqa.yaml) | `[2, 4]`   | `["data", "model"]`  | `["data"]`  | MetaMathQA    | LoRA   |
 
 
 ### Llama 3.1 70B Training
@@ -159,11 +159,10 @@ python3 blacksmith/experiments/torch/llama/xla/train.py --config blacksmith/expe
 ```
 
 #### Llama 3.1 70B Training Configurations
-
-| Architecture       | mesh_shape | mesh_axis_names                          | dataset | Method |
-| ------------------ | ---------- | ---------------------------------------- | ------- | ------ |
-| [Blackhole LoudBox](loudbox/llama_3_1_70b_sst2.yaml) | `[2, 4]`   | `["model", "batch"]`| SST2    | LoRA   |
-| [Galaxy](galaxy/llama_3_1_70b_sst2.yaml) | `[4, 8]`   | `["model", "batch"]` | SST2    | LoRA   |
+| Architecture       | mesh_shape                   | mesh_axis_names      | input_sharding_dim | dataset      | Method                      |
+| ------------------ | ---------------------------- | -------------------- | ------------------ | ------------ | --------------------------- |
+| [Blackhole LoudBox](loudbox/llama_3_1_70b_sst2.yaml) | `[2, 4]`   | `["model", "batch"]`| None | SST2    | LoRA   |
+| [Galaxy](galaxy/llama_3_1_70b_sst2.yaml) | `[4, 8]`   | `["model", "batch"]` |  None |  SST2    | LoRA   |
 
 
 ### Llama 3.3 70B Instruct Training
@@ -182,10 +181,10 @@ python3 blacksmith/experiments/torch/llama/xla/train.py --config blacksmith/expe
 
 #### Llama 3.3 70B Instruct Training Configurations
 
-| Architecture       | mesh_shape | mesh_axis_names                          | dataset | Method |
-| ------------------ | ---------- | ---------------------------------------- | ------- | ------ |
-| [Blackhole LoudBox](loudbox/llama_3_3_70b_instruct_alpaca.yaml) | `[2, 4]`   | `["model", "batch"]`                      | Alpaca    | LoRA   |
-| [Wormhole Galaxy](galaxy/llama_3_3_70b_instruct_alpaca.yaml) | `[4, 8]`   | `["model", "batch"]`                      | Alpaca    | LoRA   |
+| Architecture       | mesh_shape                   | mesh_axis_names      | input_sharding_dim | dataset      | Method                      |
+| ------------------ | ---------------------------- | -------------------- | ------------------ | ------------ | --------------------------- |
+| [Blackhole LoudBox](loudbox/llama_3_3_70b_instruct_alpaca.yaml) | `[2, 4]`   | `["model", "batch"]`    | None              | Alpaca    | LoRA   |
+| [Wormhole Galaxy](galaxy/llama_3_3_70b_instruct_alpaca.yaml) | `[4, 8]`   | `["model", "batch"]`       | None              | Alpaca    | LoRA   |
 
 ## Data
 

--- a/blacksmith/experiments/torch/llama/xla/lora/README.md
+++ b/blacksmith/experiments/torch/llama/xla/lora/README.md
@@ -70,10 +70,10 @@ python3 blacksmith/experiments/torch/llama/xla/train.py --config blacksmith/expe
 | ------------------ | ---------------------------- | -------------------- | ------------------ | ------------ | --------------------------- |
 | [Single-Chip](single_chip/llama_3_2_1b_alpaca.yaml) | None          | None            | None                     | Alpaca  | LoRA   |
 | [Single-Chip](single_chip/llama_3_2_1b_sst2.yaml) | None                         | None        | None                      | SST2    | LoRA   |
-| [N300](quietbox/llama_3_2_1b_sst2.yaml) | `[1, 2]`, `[2, 1]`           | `["data", "model"]`, `["model", "data"]` | `["batch"]`  | SST2    | LoRA   |
-| [Wormhole QuietBox](quietbox/llama_3_2_1b_sst2.yaml) | `[1, 8]`, `[8, 1]`, `[2, 4]` | `["data", "model"]`, `["model", "data"]` | `["batch"]`   | SST2    | LoRA   |
-| [Blackhole QuietBox](quietbox/llama_3_2_1b_sst2.yaml) | `[1, 4]`                     | `["data", "model"]`     | `["batch"]`            | SST2    | LoRA   |
-| [Galaxy](galaxy/llama_3_2_1b_sst2.yaml) | `[8, 4]`                     | `["data", "model"]`, `["model", "data"]`| `["batch"]`   | SST2    | LoRA   |
+| [N300](quietbox/llama_3_2_1b_sst2.yaml) | `[1, 2]`, `[2, 1]`           | `["data", "model"]`, `["model", "data"]` | `"batch"`  | SST2    | LoRA   |
+| [Wormhole QuietBox](quietbox/llama_3_2_1b_sst2.yaml) | `[1, 8]`, `[8, 1]`, `[2, 4]` | `["data", "model"]`, `["model", "data"]` | `"batch"`   | SST2    | LoRA   |
+| [Blackhole QuietBox](quietbox/llama_3_2_1b_sst2.yaml) | `[1, 4]`                     | `["data", "model"]`     | `"batch"`              | SST2    | LoRA   |
+| [Galaxy](galaxy/llama_3_2_1b_sst2.yaml) | `[8, 4]`                     | `["data", "model"]`, `["model", "data"]`| `"batch"`   | SST2    | LoRA   |
 
 ### Llama 3.2 3B Training
 

--- a/blacksmith/experiments/torch/mnist/README.md
+++ b/blacksmith/experiments/torch/mnist/README.md
@@ -39,6 +39,12 @@ python blacksmith/experiments/torch/mnist/tensor_parallel/train.py
 
 ## Configuration
 
+| Architecture       | mesh_shape                   | mesh_axis_names      | input_sharding_dim | dataset      | Method                      |
+| ------------------ | ---------------------------- | -------------------- | ------------------ | ------------ | --------------------------- |
+| [Single-Chip](single_chip/mnist.yaml) | None      | None                 | None               | MNIST        | Full Model                  |
+| [N300](data_parallel/mnist_dp.yaml)   | `[1, 2]`  | `["model", "batch"]` | `["batch"]`        | MNIST        | Full Model, Data Parallel   |
+| [N300](tensor_parallel/mnist_tp.yaml) | `[1, 2]`  | `["batch", "model"]` | None               | MNIST        | Full Model, Tensor Parallel |
+
 For each training you can change default values in configuration files:
 1. Single chip - Linear - `blacksmith/experiments/torch/mnist/single_chip/mnist.yaml`
 2. Data parallel - `blacksmith/experiments/torch/mnist/data_parallel/mnist_dp.yaml`

--- a/blacksmith/experiments/torch/mnist/README.md
+++ b/blacksmith/experiments/torch/mnist/README.md
@@ -42,7 +42,7 @@ python blacksmith/experiments/torch/mnist/tensor_parallel/train.py
 | Architecture       | mesh_shape                   | mesh_axis_names      | input_sharding_dim | dataset      | Method                      |
 | ------------------ | ---------------------------- | -------------------- | ------------------ | ------------ | --------------------------- |
 | [Single-Chip](single_chip/mnist.yaml) | None      | None                 | None               | MNIST        | Full Model                  |
-| [N300](data_parallel/mnist_dp.yaml)   | `[1, 2]`  | `["model", "batch"]` | `["batch"]`        | MNIST        | Full Model, Data Parallel   |
+| [N300](data_parallel/mnist_dp.yaml)   | `[1, 2]`  | `["model", "batch"]` | `"batch"`          | MNIST        | Full Model, Data Parallel   |
 | [N300](tensor_parallel/mnist_tp.yaml) | `[1, 2]`  | `["batch", "model"]` | None               | MNIST        | Full Model, Tensor Parallel |
 
 For each training you can change default values in configuration files:

--- a/blacksmith/experiments/torch/mnist_cnn/README.md
+++ b/blacksmith/experiments/torch/mnist_cnn/README.md
@@ -18,6 +18,10 @@ python blacksmith/experiments/torch/mnist_cnn/train.py
 
 ## Configuration
 
+| Architecture       | mesh_shape                   | mesh_axis_names      | input_sharding_dim | dataset      | Method                      |
+| ------------------ | ---------------------------- | -------------------- | ------------------ | ------------ | --------------------------- |
+| [Single-Chip](single_chip/mnist_cnn.yaml) | None      | None             | None               | MNIST        | Full Model                  |
+
 In `blacksmith/experiments/torch/mnist_cnn/single_chip/mnist_cnn.yaml` you can change values for following parameters.
 
 | Parameter | Description | Default Value |

--- a/blacksmith/experiments/torch/phi/README.md
+++ b/blacksmith/experiments/torch/phi/README.md
@@ -57,13 +57,23 @@ Example:
 
 ## Configuration
 
-### Phi=1
+### Phi-1
+
+| Architecture       | mesh_shape                   | mesh_axis_names      | input_sharding_dim | dataset      | Method                      |
+| ------------------ | ---------------------------- | -------------------- | ------------------ | ------------ | --------------------------- |
+| [Single-Chip](single_chip/phi1_sst2.yaml) | None        | None           | None           | SST-2    | LoRA      |
+| [Single-Chip](single_chip/phi1_squadV2.yaml) | None        | None           | None        | Squad-V2 | LoRA |
 
 The Phi-1 model to be trained on SST2 dataset is configured using the configuration file `phi1_sst2.yaml`. This is the default setting.
 
 The Phi-1 model to be trained on Squad-V2 dataset is configured using the configuration file `phi1_squadV2.yaml`.
 
 ### Phi-1.5
+
+| Architecture       | mesh_shape                   | mesh_axis_names      | input_sharding_dim | dataset      | Method                      |
+| ------------------ | ---------------------------- | -------------------- | ------------------ | ------------ | --------------------------- |
+| [Single-Chip](single_chip/phi15_sst2.yaml) | None        | None         | None             | SST-2    | LoRA      |
+| [Single-Chip](single_chip/phi15_squadV2.yaml) | None        | None      | None               | Squad-V2       | LoRA |
 
 The Phi-1.5 model to be trained on SST2 dataset is configured using the configuration file `phi15_sst2.yaml`. This is the default setting.
 

--- a/blacksmith/experiments/torch/qwen/README.md
+++ b/blacksmith/experiments/torch/qwen/README.md
@@ -49,9 +49,9 @@ python3 blacksmith/experiments/torch/qwen/train.py --config blacksmith/experimen
 
 #### Qwen 2.5 0.5B Training Configuration
 
-| Architecture       | mesh_shape | mesh_axis_names | dataset | Method |
-| ------------------ | ---------- | --------------- | ------- | ------ |
-| [Single-Chip](single_chip/qwen_text2sql.yaml)        | None       | None            | Text2SQL    | LoRA   |
+| Architecture       | mesh_shape                   | mesh_axis_names      | input_sharding_dim | dataset      | Method                      |
+| ------------------ | ---------------------------- | -------------------- | ------------------ | ------------ | --------------------------- |
+| [Single-Chip](single_chip/qwen_text2sql.yaml)        | None       | None     | None       | Text2SQL    | LoRA   |
 
 ### Qwen 2.5 1.5B Training
 
@@ -64,9 +64,9 @@ python3 blacksmith/experiments/torch/qwen/train.py --config blacksmith/experimen
 
 #### Qwen 2.5 1.5B Training Configuration
 
-| Architecture       | mesh_shape | mesh_axis_names | dataset | Method |
-| ------------------ | ---------- | --------------- | ------- | ------ |
-| [Single-Chip](single_chip/qwen_1-5b_text2sql.yaml)        | None       | None            | Text2SQL    | LoRA   |
+| Architecture       | mesh_shape                   | mesh_axis_names      | input_sharding_dim | dataset      | Method                      |
+| ------------------ | ---------------------------- | -------------------- | ------------------ | ------------ | --------------------------- |
+| [Single-Chip](single_chip/qwen_1-5b_text2sql.yaml)        | None       | None      | None      | Text2SQL    | LoRA   |
 
 ### Qwen 3 4B Instruct 2507 Training
 
@@ -85,11 +85,11 @@ Working mesh shapes for Blackhole QuietBox: `[1, 4]` (data, model)
 
 #### Qwen 3 4B Instruct 2507 Training Configurations
 
-| Architecture       | mesh_shape         | mesh_axis_names                           | dataset | Method |
-| ------------------ | -----------------  | ----------------------------------------- | ------- | ------ |
-| [Single-Chip](single_chip/qwen_3_4b_instruct_2507_sst2.yaml)        | None               | None                                      | SST2    | LoRA   |
-| [N300](quietbox/qwen_3_4b_instruct_2507_sst2.yaml)             | `[1, 2]`, `[2, 1]` |  `["data", "model"]`, `["model", "data"]` | SST2    | LoRA   |
-| [Blackhole QuietBox](quietbox/qwen_3_4b_instruct_2507_sst2.yaml) | `[1, 4]`           | `["data", "model"]`                       | SST2    | LoRA   |
+| Architecture       | mesh_shape                   | mesh_axis_names      | input_sharding_dim | dataset      | Method                      |
+| ------------------ | ---------------------------- | -------------------- | ------------------ | ------------ | --------------------------- |
+| [Single-Chip](single_chip/qwen_3_4b_instruct_2507_sst2.yaml)        | None               | None        | None    | SST2    | LoRA   |
+| [N300](quietbox/qwen_3_4b_instruct_2507_sst2.yaml)             | `[1, 2]`, `[2, 1]` |  `["data", "model"]`, `["model", "data"]`| None | SST2    | LoRA   |
+| [Blackhole QuietBox](quietbox/qwen_3_4b_instruct_2507_sst2.yaml) | `[1, 4]`           | `["data", "model"]`            | None   | SST2    | LoRA   |
 
 ### Qwen 3 8B Base Training
 
@@ -102,9 +102,9 @@ python3 blacksmith/experiments/torch/qwen/train.py --config blacksmith/experimen
 
 #### Qwen 3 8B Base Training Configurations
 
-| Architecture       | mesh_shape         | mesh_axis_names                           | dataset | Method |
-| ------------------ | -----------------  | ----------------------------------------- | ------- | ------ |
-| [Wormhole Galaxy](galaxy/qwen_3_8b_base_sst2.yaml)        | `[8, 4]`   | `["data", "model"]`, `["model", "data"]` | SST2    | LoRA   |
+| Architecture       | mesh_shape                   | mesh_axis_names      | input_sharding_dim | dataset      | Method                      |
+| ------------------ | ---------------------------- | -------------------- | ------------------ | ------------ | --------------------------- |
+| [Wormhole Galaxy](galaxy/qwen_3_8b_base_sst2.yaml)        | `[8, 4]`   | `["batch", "model"]`, `["model", "batch"]` |`"batch"` | SST2    | LoRA   |
 
 ### Qwen 3 8B Training
 
@@ -117,9 +117,9 @@ python3 blacksmith/experiments/torch/qwen/train.py --config blacksmith/experimen
 
 #### Qwen 3 8B Training Configurations
 
-| Architecture       | mesh_shape         | mesh_axis_names                           | dataset | Method |
-| ------------------ | -----------------  | ----------------------------------------- | ------- | ------ |
-| [Wormhole QuietBox](quietbox/qwen_3_8b_alpaca.yaml)        | `[1, 8]`, `[8, 1]`, `[2, 4]` | `["batch", "model"]`, `["model", "batch"]` | Alpaca    | LoRA   |
+| Architecture       | mesh_shape                   | mesh_axis_names      | input_sharding_dim | dataset      | Method                      |
+| ------------------ | ---------------------------- | -------------------- | ------------------ | ------------ | --------------------------- |
+| [Wormhole QuietBox](quietbox/qwen_3_8b_alpaca.yaml)  | `[1, 8]`, `[8, 1]`, `[2, 4]` | `["batch", "model"]`, `["model", "batch"]` | None   | Alpaca    | LoRA   |
 
 
 ### Qwen 3 32B Training
@@ -133,9 +133,9 @@ python3 blacksmith/experiments/torch/qwen/train.py --config blacksmith/experimen
 
 #### Qwen 3 32B Training Configurations
 
-| Architecture       | mesh_shape         | mesh_axis_names                           | dataset | Method |
-| ------------------ | -----------------  | ----------------------------------------- | ------- | ------ |
-| [Wormhole Galaxy](galaxy/qwen_3_32b_alpaca.yaml)        | `[8, 4]`   | `["model", "batch"]` | Alpaca    | LoRA   |
+| Architecture       | mesh_shape                   | mesh_axis_names      | input_sharding_dim | dataset      | Method                      |
+| ------------------ | ---------------------------- | -------------------- | ------------------ | ------------ | --------------------------- |
+| [Wormhole Galaxy](galaxy/qwen_3_32b_alpaca.yaml)        | `[8, 4]`   | `["model", "batch"]` | None   | Alpaca    | LoRA   |
 
 
 ## Data

--- a/blacksmith/experiments/torch/wan2_2/README.md
+++ b/blacksmith/experiments/torch/wan2_2/README.md
@@ -38,9 +38,10 @@ the output / FFN-down projections are row-parallel (`["batch", "model"]`), and L
 adapters keep the rank dim replicated so the fused AdamW step stays element-wise. The mesh is
 driven by `mesh_shape`/`mesh_axis_names`.
 
-| Hardware | mesh_shape | mesh_axis_names |
-| --- | --- | --- |
-| [WH QuietBox](lora/quietbox/wan2_2_ti2v_5b_diffusiondb.yaml) | `[2, 4]` | `["batch", "model"]` |
+
+| Architecture | mesh_shape | mesh_axis_names |input_sharding_dim | Dataset | Method |
+| --- | --- | --- | --- | --- | --- |
+ [BH LoudBox](lora/quietbox/wan2_2_ti2v_5b_diffusiondb.yaml) | `[2, 4]` | `["batch", "model"]` | None | PixelArt | LoRA |
 
 ## Running
 

--- a/docs/src/experiments.md
+++ b/docs/src/experiments.md
@@ -4,61 +4,43 @@ This page provides an overview of the experiments included in this repository, d
 
 ## Available Experiments
 
-The following table provides an overview of different model and dataset combinations within various frameworks explored in this project.
+The following table provides an overview of different model and method combinations within various frameworks explored in this project.
 
-| Framework | Model | Dataset | Method | Devices | Details |
-| --- | --- | --- | --- | --- | --- |
-| PyTorch | MLP | MNIST | Full-model | N150 | [README](https://github.com/tenstorrent/tt-blacksmith/blob/main/blacksmith/experiments/torch/mnist/README.md) |
-| PyTorch | CNN | MNIST | Full-model | N150 | [README](https://github.com/tenstorrent/tt-blacksmith/blob/main/blacksmith/experiments/torch/mnist_cnn/README.md) |
-| PyTorch | MLP | MNIST | Full-model, Data parallel | N300 | [README](https://github.com/tenstorrent/tt-blacksmith/blob/main/blacksmith/experiments/torch/mnist/README.md) |
-| PyTorch | MLP | MNIST | Full-model, Tensor parallel | N300 | [README](https://github.com/tenstorrent/tt-blacksmith/blob/main/blacksmith/experiments/torch/mnist/README.md) |
-| PyTorch | Llama 3.2 1B | SST-2 | LoRA | N150 | [README](https://github.com/tenstorrent/tt-blacksmith/blob/main/blacksmith/experiments/torch/llama/xla/lora/README.md) |
-| PyTorch | Llama 3.2 1B | SST-2 | LoRA, Data + Tensor parallel| T3K | [README](https://github.com/tenstorrent/tt-blacksmith/blob/main/blacksmith/experiments/torch/llama/xla/lora/README.md) |
-| PyTorch | Llama 3.2 1B | SST-2 | LoRA, Data + Tensor parallel| WH/BH Galaxy | [README](https://github.com/tenstorrent/tt-blacksmith/blob/main/blacksmith/experiments/torch/llama/xla/lora/README.md) |
-| PyTorch | Llama 3.2 1B | SST-2 | Adapters | N150 | [README](https://github.com/tenstorrent/tt-blacksmith/blob/main/blacksmith/experiments/torch/llama/xla/adapters/README.md) |
-| PyTorch | Llama 3.2 3B | FuseChat | LoRA | P150 | [README](https://github.com/tenstorrent/tt-blacksmith/blob/main/blacksmith/experiments/torch/llama/xla/lora/README.md) |
-| PyTorch | Llama 3.2 3B | FuseChat | LoRA, Tensor parallel | BH QuietBox | [README](https://github.com/tenstorrent/tt-blacksmith/blob/main/blacksmith/experiments/torch/llama/xla/lora/README.md) |
-| PyTorch | Llama 3.1 8B | SST-2 | LoRA | P150 | [README](https://github.com/tenstorrent/tt-blacksmith/blob/main/blacksmith/experiments/torch/llama/xla/lora/README.md) |
-| PyTorch | Llama 3.1 8B | SST-2 | LoRA, Data + Tensor parallel| T3K | [README](https://github.com/tenstorrent/tt-blacksmith/blob/main/blacksmith/experiments/torch/llama/xla/lora/README.md) |
-| PyTorch | Llama 3.1 8B | SST-2 | LoRA, Data + Tensor parallel| BH Galaxy | [README](https://github.com/tenstorrent/tt-blacksmith/blob/main/blacksmith/experiments/torch/llama/xla/lora/README.md) |
-| PyTorch | Llama 3.1 8B Instruct | MetaMathQA | LoRA, Data + Tensor parallel | WH QuietBox | [README](https://github.com/tenstorrent/tt-blacksmith/blob/main/blacksmith/experiments/torch/llama/xla/lora/README.md) |
-| PyTorch | Llama 3.1 70B | SST-2 | LoRA, Tensor parallel| BH LoudBox | [README](https://github.com/tenstorrent/tt-blacksmith/blob/main/blacksmith/experiments/torch/llama/xla/lora/README.md) |
-| PyTorch | Llama 3.1 70B | SST-2 | LoRA, Tensor parallel| WH Galaxy | [README](https://github.com/tenstorrent/tt-blacksmith/blob/main/blacksmith/experiments/torch/llama/xla/lora/README.md) |
-| PyTorch | Llama 3.3 70B Instruct | Alpaca | LoRA, Tensor parallel| BH LoudBox | [README](https://github.com/tenstorrent/tt-blacksmith/blob/main/blacksmith/experiments/torch/llama/xla/lora/README.md) |
-| PyTorch | Llama 3.3 70B Instruct | Alpaca | LoRA, Tensor parallel| WH Galaxy | [README](https://github.com/tenstorrent/tt-blacksmith/blob/main/blacksmith/experiments/torch/llama/xla/lora/README.md) |
-| PyTorch | GPT-OSS 20B | SST-2 | LoRA, Tensor parallel | BH LoudBox | [README](https://github.com/tenstorrent/tt-blacksmith/blob/main/blacksmith/experiments/torch/gpt_oss/README.md) |
-| PyTorch | GPT-OSS 20B | Alpaca | LoRA, Tensor parallel | WH Galaxy | [README](https://github.com/tenstorrent/tt-blacksmith/blob/main/blacksmith/experiments/torch/gpt_oss/README.md) |
-| PyTorch | GPT-OSS 120B | Alpaca | LoRA, Tensor parallel | WH Galaxy | [README](https://github.com/tenstorrent/tt-blacksmith/blob/main/blacksmith/experiments/torch/gpt_oss/README.md) |
-| PyTorch | Qwen 2.5 0.5B | Text-to-SQL | LoRA | N150 | [README](https://github.com/tenstorrent/tt-blacksmith/blob/main/blacksmith/experiments/torch/qwen/README.md) |
-| PyTorch | Qwen 2.5 1.5B | Text-to-SQL | LoRA | N150 | [README](https://github.com/tenstorrent/tt-blacksmith/blob/main/blacksmith/experiments/torch/qwen/README.md) |
-| Pytorch | Qwen 3 4B | SST-2 | LoRA | N150 | [README](https://github.com/tenstorrent/tt-blacksmith/blob/main/blacksmith/experiments/torch/qwen/README.md) |
-| Pytorch | Qwen 3 4B | SST-2 | LoRA, Tensor parallel | BH QuietBox | [README](https://github.com/tenstorrent/tt-blacksmith/blob/main/blacksmith/experiments/torch/qwen/README.md) |
-| Pytorch | Qwen 3 8B-Base | SST-2 | LoRA, Data + Tensor parallel | WH Galaxy | [README](https://github.com/tenstorrent/tt-blacksmith/blob/main/blacksmith/experiments/torch/qwen/README.md) |
-| Pytorch | Qwen 3 8B | Alpaca | LoRA, Data + Tensor parallel | BH QuietBox | [README](https://github.com/tenstorrent/tt-blacksmith/blob/main/blacksmith/experiments/torch/qwen/README.md) |
-| PyTorch | Qwen 3 32B | Alpaca | LoRA, Tensor parallel| WH Galaxy | [README](https://github.com/tenstorrent/tt-blacksmith/blob/main/blacksmith/experiments/torch/qwen/README.md) |
-| PyTorch | Gemma 3 1B | SST-2 | LoRA | N150 | [README](https://github.com/tenstorrent/tt-blacksmith/blob/main/blacksmith/experiments/torch/gemma/README.md) |
-| PyTorch | Gemma 1.1 2B | SST-2 | LoRA | N150 | [README](https://github.com/tenstorrent/tt-blacksmith/blob/main/blacksmith/experiments/torch/gemma11/lora/README.md) |
-| PyTorch | Gemma 1.1 2B | Squad-V2 | LoRA | N150 | [README](https://github.com/tenstorrent/tt-blacksmith/blob/main/blacksmith/experiments/torch/gemma11/lora/README.md) |
-| PyTorch | Gemma 1.1 2B | Math Preference | LoRA | P150 | [README](https://github.com/tenstorrent/tt-blacksmith/blob/main/blacksmith/experiments/torch/gemma11/lora/README.md) |
-| PyTorch | Gemma 1.1 2B | Math Preference | LoRA, DPO | P150 | [README](https://github.com/tenstorrent/tt-blacksmith/blob/main/blacksmith/experiments/torch/gemma11/dpo/README.md) |
-| PyTorch | Gemma 4 E2B Instruct | WizardLM-Evol | LoRA, Tensor parallel | BH LoudBox | [README](https://github.com/tenstorrent/tt-blacksmith/blob/main/blacksmith/experiments/torch/gemma4/README.md) |
-| PyTorch | ALBERT | Banking77 | Adapters | N150 | [README](https://github.com/tenstorrent/tt-blacksmith/blob/main/blacksmith/experiments/torch/albert/README.md) |
-| PyTorch | Phi-1 | SST-2 | LoRA | N150 | [README](https://github.com/tenstorrent/tt-blacksmith/blob/main/blacksmith/experiments/torch/phi/README.md) |
-| PyTorch | Phi-1 | Squad-V2 | LoRA | N150 | [README](https://github.com/tenstorrent/tt-blacksmith/blob/main/blacksmith/experiments/torch/phi/README.md) |
-| PyTorch | Phi-1.5 | SST-2 | LoRA | N150 | [README](https://github.com/tenstorrent/tt-blacksmith/blob/main/blacksmith/experiments/torch/phi/README.md) |
-| PyTorch | Phi-1.5 | Squad-V2 | LoRA | N150 | [README](https://github.com/tenstorrent/tt-blacksmith/blob/main/blacksmith/experiments/torch/phi/README.md) |
-| PyTorch | GATv2 | PubMed | Full-model | N150 | [README](https://github.com/tenstorrent/tt-blacksmith/blob/main/blacksmith/experiments/torch/BOUNTIES/gatv2_pubmed/README.md) |
-| PyTorch | Wan 2.2 5b | PixelArt | LoRA, Tensor parallel | BH LoudBox | [README](https://github.com/tenstorrent/tt-blacksmith/blob/main/blacksmith/experiments/torch/wan2_2/README.md) |
-| JAX | MLP | MNIST | Full-model | N150 | [README](https://github.com/tenstorrent/tt-blacksmith/blob/main/blacksmith/experiments/jax/mnist/README.md) |
-| JAX | MLP | MNIST | Full-model, Data parallel | N300 | [README](https://github.com/tenstorrent/tt-blacksmith/blob/main/blacksmith/experiments/jax/mnist/README.md) |
-| JAX | MLP | MNIST | Full-model, Tensor parallel | N300 | [README](https://github.com/tenstorrent/tt-blacksmith/blob/main/blacksmith/experiments/jax/mnist/README.md) |
-| JAX | NeRF | Blender | Full-model | N150 | [README](https://github.com/tenstorrent/tt-blacksmith/blob/main/blacksmith/experiments/jax/nerf/README.md) |
-| JAX | Llama 3.2 1B | SST-2 | LoRA | N150 | [README](https://github.com/tenstorrent/tt-blacksmith/blob/main/blacksmith/experiments/jax/llama/lora/README.md) |
-| JAX | Llama 3.2 1B | SST-2 | DoRA | N150 | [README](https://github.com/tenstorrent/tt-blacksmith/blob/main/blacksmith/experiments/jax/llama/dora/README.md) |
-| JAX | DistilBERT | SST-2 | Distillation | N150 | [README](https://github.com/tenstorrent/tt-blacksmith/blob/main/blacksmith/experiments/jax/distil_bert/README.md) |
-| JAX | DistilBERT | SST-2 | Distillation, Data parallel | N300 | [README](https://github.com/tenstorrent/tt-blacksmith/blob/main/blacksmith/experiments/jax/distil_bert/README.md) |
-| EasyDel | Qwen 3 0.6B | SST-2 | LoRA | N150 | [README](https://github.com/tenstorrent/tt-blacksmith/blob/main/blacksmith/experiments/easydel/qwen/lora/README.md) |
-| Lightning | NeRF | Blender | Full-model | N150 | [README](https://github.com/tenstorrent/tt-blacksmith/blob/main/blacksmith/experiments/lightning/nerf/README.md) |
+| Framework | Model | Method  | Details |
+| --------- | ----- | ------- | ------- |
+| PyTorch | MLP | Full-model  | [README](https://github.com/tenstorrent/tt-blacksmith/blob/main/blacksmith/experiments/torch/mnist/README.md) |
+| PyTorch | CNN | Full-model | [README](https://github.com/tenstorrent/tt-blacksmith/blob/main/blacksmith/experiments/torch/mnist_cnn/README.md) |
+| PyTorch | Llama 3.2 1B | LoRA | [README](https://github.com/tenstorrent/tt-blacksmith/blob/main/blacksmith/experiments/torch/llama/xla/lora/README.md#llama-32-1b-training) |
+| PyTorch | Llama 3.2 1B | Adapters | [README](https://github.com/tenstorrent/tt-blacksmith/blob/main/blacksmith/experiments/torch/llama/xla/adapters/README.md) |
+| PyTorch | Llama 3.2 3B | LoRA | [README](https://github.com/tenstorrent/tt-blacksmith/blob/main/blacksmith/experiments/torch/llama/xla/lora/README.md#llama-32-3b-training) |
+| PyTorch | Llama 3.1 8B | LoRA | [README](https://github.com/tenstorrent/tt-blacksmith/blob/main/blacksmith/experiments/torch/llama/xla/lora/README.md#llama-31-8b-training) |
+| PyTorch | Llama 3.1 8B Instruct | LoRA | [README](https://github.com/tenstorrent/tt-blacksmith/blob/main/blacksmith/experiments/torch/llama/xla/lora/README.md#llama-31-8b-instruct-training) |
+| PyTorch | Llama 3.1 70B | LoRA| [README](https://github.com/tenstorrent/tt-blacksmith/blob/main/blacksmith/experiments/torch/llama/xla/lora/README.md#llama-31-70b-training) |
+| PyTorch | Llama 3.3 70B Instruct | LoRA| [README](https://github.com/tenstorrent/tt-blacksmith/blob/main/blacksmith/experiments/torch/llama/xla/lora/README.md#llama-33-70b-instruct-training) |
+| PyTorch | GPT-OSS 20B | LoRA | [README](https://github.com/tenstorrent/tt-blacksmith/blob/main/blacksmith/experiments/torch/gpt_oss/README.md#gpt-oss-20b-training) |
+| PyTorch | GPT-OSS 120B | LoRA | [README](https://github.com/tenstorrent/tt-blacksmith/blob/main/blacksmith/experiments/torch/gpt_oss/README.md#gpt-oss-120b-training) |
+| PyTorch | Qwen 2.5 0.5B | LoRA | [README](https://github.com/tenstorrent/tt-blacksmith/blob/main/blacksmith/experiments/torch/qwen/README.md#qwen-25-05b-training) |
+| PyTorch | Qwen 2.5 1.5B | LoRA | [README](https://github.com/tenstorrent/tt-blacksmith/blob/main/blacksmith/experiments/torch/qwen/README.md#qwen-25-15b-training) |
+| Pytorch | Qwen 3 4B Instruct 2507 | LoRA | [README](https://github.com/tenstorrent/tt-blacksmith/blob/main/blacksmith/experiments/torch/qwen/README.md#qwen-3-4b-instruct-2507-training) |
+| Pytorch | Qwen 3 8B-Base | LoRA| [README](https://github.com/tenstorrent/tt-blacksmith/blob/main/blacksmith/experiments/torch/qwen/README.md#qwen-3-8b-base-training) |
+| Pytorch | Qwen 3 8B | LoRA | [README](https://github.com/tenstorrent/tt-blacksmith/blob/main/blacksmith/experiments/torch/qwen/README.md#qwen-3-8b-training) |
+| PyTorch | Qwen 3 32B | LoRA | [README](https://github.com/tenstorrent/tt-blacksmith/blob/main/blacksmith/experiments/torch/qwen/README.md#qwen-3-32b-training) |
+| PyTorch | Gemma 3 1B | LoRA | [README](https://github.com/tenstorrent/tt-blacksmith/blob/main/blacksmith/experiments/torch/gemma/README.md) |
+| PyTorch | Gemma 1.1 2B | LoRA | [README](https://github.com/tenstorrent/tt-blacksmith/blob/main/blacksmith/experiments/torch/gemma11/lora/README.md) |
+| PyTorch | Gemma 1.1 2B | LoRA, DPO | [README](https://github.com/tenstorrent/tt-blacksmith/blob/main/blacksmith/experiments/torch/gemma11/dpo/README.md) |
+| PyTorch | Gemma 4 E2B Instruct | LoRA | [README](https://github.com/tenstorrent/tt-blacksmith/blob/main/blacksmith/experiments/torch/gemma4/README.md) |
+| PyTorch | ALBERT | Adapters | [README](https://github.com/tenstorrent/tt-blacksmith/blob/main/blacksmith/experiments/torch/albert/README.md) |
+| PyTorch | Phi-1 | LoRA | [README](https://github.com/tenstorrent/tt-blacksmith/blob/main/blacksmith/experiments/torch/phi/README.md#phi1) |
+| PyTorch | Phi-1.5 | LoRA | [README](https://github.com/tenstorrent/tt-blacksmith/blob/main/blacksmith/experiments/torch/phi/README.md#phi-15) |
+| PyTorch | GATv2 | Full-model | [README](https://github.com/tenstorrent/tt-blacksmith/blob/main/blacksmith/experiments/torch/BOUNTIES/gatv2_pubmed/README.md) |
+| PyTorch | Wan 2.2 5b | LoRA | [README](https://github.com/tenstorrent/tt-blacksmith/blob/main/blacksmith/experiments/torch/wan2_2/README.md) |
+| JAX | MLP | Full-model | [README](https://github.com/tenstorrent/tt-blacksmith/blob/main/blacksmith/experiments/jax/mnist/README.md) |
+| JAX | NeRF | Full-model | [README](https://github.com/tenstorrent/tt-blacksmith/blob/main/blacksmith/experiments/jax/nerf/README.md) |
+| JAX | Llama 3.2 1B | LoRA | [README](https://github.com/tenstorrent/tt-blacksmith/blob/main/blacksmith/experiments/jax/llama/lora/README.md) |
+| JAX | Llama 3.2 1B | DoRA | [README](https://github.com/tenstorrent/tt-blacksmith/blob/main/blacksmith/experiments/jax/llama/dora/README.md) |
+| JAX | DistilBERT | Distillation | [README](https://github.com/tenstorrent/tt-blacksmith/blob/main/blacksmith/experiments/jax/distil_bert/README.md) |
+| EasyDel | Qwen 3 0.6B | LoRA | [README](https://github.com/tenstorrent/tt-blacksmith/blob/main/blacksmith/experiments/easydel/qwen/lora/README.md) |
+| Lightning | NeRF | Full-model | [README](https://github.com/tenstorrent/tt-blacksmith/blob/main/blacksmith/experiments/lightning/nerf/README.md) |
 
 
 ## Navigating the Experiment Structure
@@ -66,11 +48,11 @@ Within this repository, you'll find the following structure to help you navigate
 
 - `datasets/`: The dataset loaders for specific model training are defined in this directory and organized by the framework they utilize. For example, the loader for the MNIST dataset in PyTorch can be found at `datasets/torch/mnist/`.
 - `models/`: This directory is organized by framework. Within it, you'll find subdirectories (e.g., `jax/`, `torch/`) containing the model implementations or loader scripts specific to that framework. For instance, the PyTorch implementation of a model for MNIST training would be located in `models/torch/mnist/`.
-- `experiments/`: Experiments are organized first by the framework they utilize, and then by the specific model or task. For example, the PyTorch-based MNIST experiment can be found under `experiments/torch/mnist/`. Within each experiment directory, you will typically find the following files:
+- `experiments/`: Experiments are organized first by the framework they utilize, and then by the specific model or task. For example, the PyTorch-based MNIST experiment can be found under `experiments/torch/mnist/`. Within each experiment directory, you will typically find the following subdirectories and files:
 
+    - Subdirectories named after fine-tuning methods used in experiments (e.g. `lora`, `dpo`, `adapters`). 
+    - Subdirectories specifying the compute environment (e.g. `single_chip`, `quietbox`, `loudbox`, `galaxy`) or sharding strategy (`data_parallel`, `tensor_parallel`). If sharding strategy isn't specified, the single chip configuration is assumed.
+    - Within these subdirectories there are YAML files containing the specific configuration parameters, named after the model and dataset used (e.g. `gemma11_sst2.yaml` - the full path in the `experiments` directory for this file is `torch/gemma11/lora/single_chip/gemma11_sst2.yaml`).
     - A Python file defining the configuration structure for the experiment (e.g. `configs.py`).
-    - A YAML file containing the specific configuration parameters for a particular run of the experiment (e.g. `test_mnist_training.yaml`).
-    - The Python script responsible for running the experiment using the defined configurations (e.g. `test_mnist_training.py`), which may be located within subdirectories which specify the compute environment or sharding strategy:
-        - `single_chip/`: Contains experiments designed to run on a single chip.
-        - `galaxy/`, `quietbox/`: Contains experiments designed to run across multiple chips, further organized in subdirectories by sharding strategy (e.g. data-parallel or tensor-parallel).
-        - If sharding strategy isn't specified, the single chip configuration is assumed.
+    - A Python training script (`train.py`) responsible for running the experiment using the defined configurations.
+    - A README file listing all experiments with the given model and fine-tuning method.

--- a/docs/src/experiments.md
+++ b/docs/src/experiments.md
@@ -50,8 +50,8 @@ Within this repository, you'll find the following structure to help you navigate
 - `models/`: This directory is organized by framework. Within it, you'll find subdirectories (e.g., `jax/`, `torch/`) containing the model implementations or loader scripts specific to that framework. For instance, the PyTorch implementation of a model for MNIST training would be located in `models/torch/mnist/`.
 - `experiments/`: Experiments are organized first by the framework they utilize, and then by the specific model or task. For example, the PyTorch-based MNIST experiment can be found under `experiments/torch/mnist/`. Within each experiment directory, you will typically find the following subdirectories and files:
 
-    - Subdirectories named after fine-tuning methods used in experiments (e.g. `lora`, `dpo`, `adapters`). 
-    - Subdirectories specifying the compute environment (e.g. `single_chip`, `quietbox`, `loudbox`, `galaxy`) or sharding strategy (`data_parallel`, `tensor_parallel`). If sharding strategy isn't specified, the single chip configuration is assumed.
+    - Subdirectories named after fine-tuning methods used in experiments (e.g. `lora`, `dpo`, `adapters`).
+    - Subdirectories specifying the compute environment (e.g. `single_chip`, `quietbox`, `loudbox`, `galaxy`).
     - Within these subdirectories there are YAML files containing the specific configuration parameters, named after the model and dataset used (e.g. `gemma11_sst2.yaml` - the full path in the `experiments` directory for this file is `torch/gemma11/lora/single_chip/gemma11_sst2.yaml`).
     - A Python file defining the configuration structure for the experiment (e.g. `configs.py`).
     - A Python training script (`train.py`) responsible for running the experiment using the defined configurations.


### PR DESCRIPTION
### Issue
Closes https://github.com/tenstorrent/tt-blacksmith/issues/526

### Problem description
The experiment table is becoming increasingly hard to read due to many experiments logged. 

### What's Changed

- Dataset and device info moved to the corresponding README files. Now the table contains frameworks, model names, fine tuning methods, and links to READMEs.

- One row kept per model + method (in a given framework). There were multiple lines for experiments using the same model and method but different parallelism strategies. Strategy info (input_sharding_dim) moved to README configuration tables, together with info from the previous point.

### Checklist
- [ ] New/Existing tests provide coverage for changes
