### PR TITLE
fix(docs): correct TT-NN Visualizer nav link

### DIFF
--- a/docs/shared/_templates/layout.html
+++ b/docs/shared/_templates/layout.html
@@ -54,7 +54,7 @@
           <a href="https://github.com/tenstorrent/tt-studio" target="_blank" rel="noopener">TT-Studio</a>
           <a href="https://github.com/tenstorrent/tt-smi" target="_blank" rel="noopener">TT-SMI</a>
           <a href="https://docs.tenstorrent.com/tt-toplike/" target="_blank" rel="noopener">TT-Toplike</a>
-          <a href="https://tenstorrent.github.io/tt-visualizer/" target="_blank" rel="noopener">TT-NN Visualizer</a>
+          <a href="https://docs.tenstorrent.com/ttnn-visualizer/" target="_blank" rel="noopener">TT-NN Visualizer</a>
           <a href="https://github.com/tenstorrent/tt-topology" target="_blank" rel="noopener">TT-Topology</a>
           <a href="https://docs.tenstorrent.com/tt-vscode-toolkit" target="_blank" rel="noopener">TT-VSCode-Toolkit</a>
           <a href="https://docs.tenstorrent.com/tt-blacksmith/" target="_blank" rel="noopener">TT-Blacksmith</a>


### PR DESCRIPTION
## Summary
The **TT-NN Visualizer** entry in the Tools nav dropdown pointed to a wrong URL (wrong host and slug) → 404:
`https://tenstorrent.github.io/tt-visualizer/`

Corrected to the canonical docs URL, matching the neighboring nav links (TT-Toplike, TT-VSCode-Toolkit, TT-Blacksmith all use `docs.tenstorrent.com`):
`https://docs.tenstorrent.com/ttnn-visualizer/`

## Change
- `docs/shared/_templates/layout.html` — single link href updated.