### PR TITLE
Disable AOT Autograd

### DIFF
--- a/blacksmith/experiments/torch/llama/xla/train.py
+++ b/blacksmith/experiments/torch/llama/xla/train.py
@@ -133,6 +133,7 @@ def train(
             "tt_enable_torch_fx_fusion_pass": False,
             "tt_legacy_compile": True,
             "tt_lazy_execution": True,
+            "tt_use_aot_autograd": False,
         }
         compute_loss_fn = torch.compile(compute_loss, backend="tt", options=compile_options)
         eval_model = torch.compile(model, backend="tt", options=compile_options)

--- a/blacksmith/models/torch/huggingface/hf_models.py
+++ b/blacksmith/models/torch/huggingface/hf_models.py
@@ -85,7 +85,11 @@ def get_model(config: TrainingConfig, device: torch.device, compile_model: bool 
             )
 
     if config.use_tt and compile_model:
-        compile_options = {"tt_enable_torch_fx_fusion_pass": False, "tt_legacy_compile": True}
+        compile_options = {
+            "tt_enable_torch_fx_fusion_pass": False,
+            "tt_legacy_compile": True,
+            "tt_use_aot_autograd": False,
+        }
         model = torch.compile(model, backend="tt", options=compile_options)
 
     return model

--- a/blacksmith/models/torch/wan2_2/device.py
+++ b/blacksmith/models/torch/wan2_2/device.py
@@ -12,6 +12,7 @@ _TORCH_COMPILE_OPTIONS = {
     "tt_enable_torch_fx_fusion_pass": False,
     "tt_legacy_compile": True,
     "tt_enable_composite_ops": True,
+    "tt_use_aot_autograd": False,
 }
 
 # XLA custom compile options. Values must be strings (the API does not coerce bool/int).


### PR DESCRIPTION
CI tests are falling with the error: _LLVM ERROR: SmallVector unable to grow. Requested capacity (4361590581) is larger than maximum value for size type (4294967295)_

The cause is when aot autograd is enabled, torch-xla is causing the error above. 

These CI jobs are falling:
- https://github.com/tenstorrent/tt-blacksmith/actions/runs/29723254816/job/88290578511?pr=668
- https://github.com/tenstorrent/tt-blacksmith/actions/runs/29723254816/job/88290578524?pr=668
- https://github.com/tenstorrent/tt-blacksmith/actions/runs/29723254816/job/88290578583?pr=668
- https://github.com/tenstorrent/tt-blacksmith/actions/runs/29723254816/job/88290578583?pr=668

The uplift PR:
- https://github.com/tenstorrent/tt-blacksmith/pull/668
