### PR TITLE
Refactor Reproducibility Manager Not to Depend on Jax

### DIFF
--- a/blacksmith/experiments/easydel/qwen/lora/train.py
+++ b/blacksmith/experiments/easydel/qwen/lora/train.py
@@ -25,7 +25,7 @@ from blacksmith.tools.jax.easydel.train_steps import (
     evaluate,
 )
 from blacksmith.tools.logging_manager import TrainingLogger
-from blacksmith.tools.reproducibility_manager import ReproducibilityManager
+from blacksmith.tools.jax.reproducibility_manager import JaxReproducibilityManager
 
 
 def validate(
@@ -319,7 +319,7 @@ if __name__ == "__main__":
     config: TrainingConfig = generate_config(TrainingConfig, args.config, args.test_config, args.test_checkpoint_path)
 
     # Reproducibility setup.
-    ReproducibilityManager(config).setup()
+    JaxReproducibilityManager(config).setup()
 
     # Logger setup.
     logger = TrainingLogger(config, args.test_log_filename_prefix)

--- a/blacksmith/experiments/easydel/qwen/lora/train.py
+++ b/blacksmith/experiments/easydel/qwen/lora/train.py
@@ -24,8 +24,8 @@ from blacksmith.tools.jax.easydel.train_steps import (
     create_fused_train_step_fn,
     evaluate,
 )
-from blacksmith.tools.logging_manager import TrainingLogger
 from blacksmith.tools.jax.reproducibility_manager import JaxReproducibilityManager
+from blacksmith.tools.logging_manager import TrainingLogger
 
 
 def validate(

--- a/blacksmith/tools/jax/reproducibility_manager.py
+++ b/blacksmith/tools/jax/reproducibility_manager.py
@@ -1,30 +1,30 @@
-# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
 #
 # SPDX-License-Identifier: Apache-2.0
 
 import random
 
+import jax
 import numpy as np
-import torch
 
 from blacksmith.tools.templates.configs import TrainingConfig
 
 
-class ReproducibilityManager:
+class JaxReproducibilityManager:
+    """JAX/EasyDel counterpart to ReproducibilityManager."""
+
     def __init__(self, config: TrainingConfig):
         self.config = config
 
     def setup(self):
         self._setup_python()
 
-        torch.manual_seed(self.config.seed)
-        torch.cuda.manual_seed(self.config.seed)
-        torch.cuda.manual_seed_all(self.config.seed)
-
         if self.config.deterministic:
-            torch.backends.cudnn.deterministic = True
-            torch.backends.cudnn.benchmark = False
+            jax.config.update("jax_default_matmul_precision", "highest")
 
     def _setup_python(self):
         random.seed(self.config.seed)
         np.random.seed(self.config.seed)
+
+    def get_jax_rng(self):
+        return jax.random.PRNGKey(self.config.seed)

--- a/blacksmith/tools/jax/reproducibility_manager.py
+++ b/blacksmith/tools/jax/reproducibility_manager.py
@@ -17,12 +17,12 @@ class JaxReproducibilityManager:
         self.config = config
 
     def setup(self):
-        self._setup_python()
+        self._seed_python_rngs()
 
         if self.config.deterministic:
             jax.config.update("jax_default_matmul_precision", "highest")
 
-    def _setup_python(self):
+    def _seed_python_rngs(self):
         random.seed(self.config.seed)
         np.random.seed(self.config.seed)
 

--- a/blacksmith/tools/reproducibility_manager.py
+++ b/blacksmith/tools/reproducibility_manager.py
@@ -15,7 +15,7 @@ class ReproducibilityManager:
         self.config = config
 
     def setup(self):
-        self._setup_python()
+        self._seed_python_rngs()
 
         torch.manual_seed(self.config.seed)
         torch.cuda.manual_seed(self.config.seed)
@@ -25,6 +25,6 @@ class ReproducibilityManager:
             torch.backends.cudnn.deterministic = True
             torch.backends.cudnn.benchmark = False
 
-    def _setup_python(self):
+    def _seed_python_rngs(self):
         random.seed(self.config.seed)
         np.random.seed(self.config.seed)


### PR DESCRIPTION
### Issue
N/A

### Bug Description
Currently reproducibility manager is shared between jax and torch. This dependency makes it impossible to load tt-blacksmith's trainer only for torch purposes, without importing jax.

### What's Changed
Split reproducibility manager into two separate ones. In future if we decide to merge efforts, we can add base class that both extend.