### PR TITLE
[Trainer] Fix Callback Calls in Trainer Class

### DIFF
--- a/blacksmith/tools/trainer/callback.py
+++ b/blacksmith/tools/trainer/callback.py
@@ -47,7 +47,7 @@ class Callback(ABC):
     def on_backward_start(self, trainer, loss, *args, **kwargs):
         pass
 
-    def on_backward_end(self, trainer, *args, **kwargs):
+    def on_backward_end(self, trainer, loss, *args, **kwargs):
         pass
 
     def on_optimizer_step_start(self, trainer, *args, **kwargs):

--- a/blacksmith/tools/trainer/callbacks/metrics_callback.py
+++ b/blacksmith/tools/trainer/callbacks/metrics_callback.py
@@ -42,8 +42,6 @@ class MetricsCallback(Callback):
             trainer.logger.watch_model(trainer.model)
 
     def on_backward_end(self, trainer, loss, *args, **kwargs):
-        # After the trainer's post-backward sync so ``loss.item()`` does not force
-        # a forward-only XLA execute before backward is attached to the graph.
         # Fires for every micro-batch; accumulate each one so the per-step loss is
         # the mean over the step's micro-batches.
         self._step_running_loss += loss.item()

--- a/blacksmith/tools/trainer/callbacks/metrics_callback.py
+++ b/blacksmith/tools/trainer/callbacks/metrics_callback.py
@@ -41,7 +41,9 @@ class MetricsCallback(Callback):
         if trainer.config.logging.model_to_wandb:
             trainer.logger.watch_model(trainer.model)
 
-    def on_forward_end(self, trainer, loss, *args, **kwargs):
+    def on_backward_end(self, trainer, loss, *args, **kwargs):
+        # After the trainer's post-backward sync so ``loss.item()`` does not force
+        # a forward-only XLA execute before backward is attached to the graph.
         # Fires for every micro-batch; accumulate each one so the per-step loss is
         # the mean over the step's micro-batches.
         self._step_running_loss += loss.item()

--- a/blacksmith/tools/trainer/trainer.py
+++ b/blacksmith/tools/trainer/trainer.py
@@ -139,7 +139,7 @@ class Trainer(ABC):
                     self._backward(loss / grad_accumulation_steps)
                     if self.config.use_tt:
                         torch_xla.sync(wait=True)
-                    self.callback_handler("on_backward_end")
+                    self.callback_handler("on_backward_end", loss)
 
                     accumulation_step += 1
 
@@ -211,7 +211,6 @@ class Trainer(ABC):
         Step the optimizer and reset gradients. Override for custom behaviour.
         """
         self.device_manager.optimizer_step(self.optimizer)
-        self.optimizer.zero_grad()
 
     def cleanup(self) -> None:
         """


### PR DESCRIPTION
### Issue
N/A

### Problem description
MetricsCallback was breaking graph in the point between forward and backward graph.

### What's Changed
This PR fixes:
- Double `zero_grad` on optimizer
- Move `loss.item()` accumulation from forward_end to backward_end.

### Checklist
- [ ] New/Existing tests provide coverage for changes
