### PR TITLE
[Trainer] Fix Bug Where Zero Grad was Left Out

### DIFF
--- a/blacksmith/tools/trainer/trainer.py
+++ b/blacksmith/tools/trainer/trainer.py
@@ -210,7 +210,9 @@ class Trainer(ABC):
         """
         Step the optimizer and reset gradients. Override for custom behaviour.
         """
-        self.device_manager.optimizer_step(self.optimizer)
+        # Re-zero in place so leftover grads do not accumulate across windows
+        # and the next window's .grad tensors stay non-None.
+        self.device_manager.optimizer_step(self.optimizer, zero_grad=True)
 
     def cleanup(self) -> None:
         """

--- a/blacksmith/tools/trainer/trainer.py
+++ b/blacksmith/tools/trainer/trainer.py
@@ -210,8 +210,6 @@ class Trainer(ABC):
         """
         Step the optimizer and reset gradients. Override for custom behaviour.
         """
-        # Re-zero in place so leftover grads do not accumulate across windows
-        # and the next window's .grad tensors stay non-None.
         self.device_manager.optimizer_step(self.optimizer, zero_grad=True)
 
     def cleanup(self) -> None:


### PR DESCRIPTION
#### Problem Description

In Trainer class training for LoRA LLM, we forgot to do `zero_grad` on optimizer after each optimizer step. Thanks to @mcupacTT for finding this out.

#### Changes Included

This PR adds flag `zero_grad` to True, to our optimizer step.
