### PR TITLE
Fix SST2 id for huggingface failing to load with newer versions of `datasets` library 

### DIFF
--- a/blacksmith/datasets/torch/sst2/sst2_utils.py
+++ b/blacksmith/datasets/torch/sst2/sst2_utils.py
@@ -21,5 +21,5 @@ RESPONSE_TEMPLATE = Template('{"label": "$label"}')
 LBL2VALUE = {0: "negative", 1: "positive"}
 VALUE2LBL = {"negative": 0, "positive": 1}
 
-DATASET_BENCHMARK = "glue"
+DATASET_BENCHMARK = "nyu-mll/glue"
 DATASET_NAME = "sst2"


### PR DESCRIPTION
### Issue
N/A

### Bug Description
SST-2 training fails on huggingface_hub ≥ 1.16 (datasets 5.x) with:

```
Invalid HF URI 'hf://datasets/glue@…/.huggingface.yaml'. Repository id must be 'namespace/name', got 'glue'.
```

The Hub still hosts glue. The client’s `hf://` parser no longer accepts canonical single-segment ids.

### What's Changed
`DATASET_BENCHMARK` in `blacksmith/datasets/torch/sst2/sst2_utils.py` is now `nyu-mll/glue`, so load_dataset builds a namespaced URI the current hub client accepts.