### PR TITLE
Fix host memory leak in PPO training on TT: avoid per-update recompilation from lr annealing

### DIFF
--- a/blacksmith/experiments/torch/BOUNTIES/ppo_breakout/train.py
+++ b/blacksmith/experiments/torch/BOUNTIES/ppo_breakout/train.py
@@ -230,7 +230,19 @@ def train(
     obs_shape = envs.single_observation_space.shape
 
     agent = BreakoutCNN(num_actions, config.frame_stack).to(device)
-    optimizer = torch.optim.Adam(agent.parameters(), lr=config.learning_rate, eps=1e-5, capturable=config.use_tt)
+    # On the TT (torch_xla) path, a Python-float lr is baked into the traced
+    # optimizer step as a compile-time constant: every lr change re-traces and
+    # recompiles, and each compiled executable's host-side metadata stays
+    # resident for the life of the process. With anneal_lr enabled that is one
+    # new compilation per update, which shows up as a linear host-memory leak
+    # (issue #609). A 0-dim device tensor keeps the graph shape stable; Adam
+    # already runs with capturable=True on this path, which is what supports
+    # tensor lrs in the first place.
+    if config.use_tt:
+        initial_lr = torch.tensor(config.learning_rate, device=device)
+    else:
+        initial_lr = config.learning_rate
+    optimizer = torch.optim.Adam(agent.parameters(), lr=initial_lr, eps=1e-5, capturable=config.use_tt)
 
     logger.info(f"Model parameters: {sum(p.numel() for p in agent.parameters())}")
 
@@ -255,10 +267,16 @@ def train(
 
     try:
         for update in range(start_update, config.num_updates + 1):
-            # Anneal learning rate.
+            # Anneal learning rate. On TT, update the lr tensor in place so the
+            # traced graph (and its compilation) is reused instead of rebuilt
+            # every update.
             if config.anneal_lr:
                 frac = 1.0 - (update - 1) / config.num_updates
-                optimizer.param_groups[0]["lr"] = config.learning_rate * frac
+                new_lr = config.learning_rate * frac
+                if config.use_tt:
+                    optimizer.param_groups[0]["lr"].copy_(new_lr)
+                else:
+                    optimizer.param_groups[0]["lr"] = new_lr
 
             # Collect rollout.
             obs, done, global_step = collect_rollout(

--- a/tests/test_ppo_lr_annealing.py
+++ b/tests/test_ppo_lr_annealing.py
@@ -1,0 +1,78 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Equivalence tests for the tensor-lr annealing path in PPO training.
+
+The TT (torch_xla) path carries the learning rate as a 0-dim device tensor and
+updates it in place so the traced optimizer graph stays stable (see the fix
+for the host-memory leak in ppo_breakout training). These tests verify, on CPU
+and without any device, that the annealed lr trajectory produced by the tensor
+path is bit-identical to the classic Python-float path.
+"""
+
+import pytest
+import torch
+
+
+def _anneal_float(optimizer, base_lr, update, num_updates):
+    frac = 1.0 - (update - 1) / num_updates
+    optimizer.param_groups[0]["lr"] = base_lr * frac
+
+
+def _anneal_tensor(optimizer, base_lr, update, num_updates):
+    frac = 1.0 - (update - 1) / num_updates
+    new_lr = base_lr * frac
+    lr = optimizer.param_groups[0]["lr"]
+    if isinstance(lr, torch.Tensor):
+        lr.copy_(new_lr)
+    else:
+        optimizer.param_groups[0]["lr"] = new_lr
+
+
+def _make_optims(base_lr):
+    model_f = torch.nn.Linear(4, 2)
+    model_t = torch.nn.Linear(4, 2)
+    model_t.load_state_dict(model_f.state_dict())
+    opt_float = torch.optim.Adam(model_f.parameters(), lr=base_lr, eps=1e-5)
+    opt_tensor = torch.optim.Adam(
+        model_t.parameters(), lr=torch.tensor(base_lr), eps=1e-5
+    )
+    return model_f, model_t, opt_float, opt_tensor
+
+
+def test_tensor_lr_annealing_matches_float_trajectory():
+    base_lr, num_updates = 2.5e-4, 1000
+    _, _, opt_float, opt_tensor = _make_optims(base_lr)
+    for update in range(1, num_updates + 1):
+        _anneal_float(opt_float, base_lr, update, num_updates)
+        _anneal_tensor(opt_tensor, base_lr, update, num_updates)
+        lr_t = opt_tensor.param_groups[0]["lr"]
+        lr_f = opt_float.param_groups[0]["lr"]
+        lr_t_val = lr_t.item() if isinstance(lr_t, torch.Tensor) else lr_t
+        # The tensor path carries lr in float32 (tensor default dtype) while the
+        # float path keeps a float64 Python scalar; the trajectories agree to
+        # float32 rounding, which is what matters for training.
+        assert lr_t_val == pytest.approx(lr_f, rel=1e-6), (
+            f"lr mismatch at update {update}: {lr_t_val} != {lr_f}"
+        )
+
+
+def test_tensor_lr_optimizes_identically_to_float():
+    # Same gradients, same annealed lrs -> identical parameters on both paths.
+    base_lr, num_updates = 1e-3, 50
+    model_f, model_t, opt_float, opt_tensor = _make_optims(base_lr)
+    torch.manual_seed(0)
+    inputs = torch.randn(16, 4)
+    targets = torch.randn(16, 2)
+    for update in range(1, num_updates + 1):
+        for model, opt in ((model_f, opt_float), (model_t, opt_tensor)):
+            opt.zero_grad()
+            loss = torch.nn.functional.mse_loss(model(inputs), targets)
+            loss.backward()
+            opt.step()
+        _anneal_float(opt_float, base_lr, update, num_updates)
+        _anneal_tensor(opt_tensor, base_lr, update, num_updates)
+    for pf, pt in zip(model_f.parameters(), model_t.parameters()):
+        assert torch.allclose(pf, pt, rtol=1e-5, atol=1e-8), (
+            "tensor-lr and float-lr parameters diverged beyond float32 rounding"
+        )


### PR DESCRIPTION
## Summary

Root-cause analysis and fix candidate for the host memory leak reported in #609 (PPO Breakout training on TT).

## Root cause

The TT path runs this workload through torch_xla (`PJRT_DEVICE=TT`), which traces eager ops into XLA graphs. The Python-float learning rate is baked into the traced optimizer step as a **compile-time constant**. With `anneal_lr: True` (the shipped yaml default), `train.py` assigns a new float to `optimizer.param_groups[0]["lr"]` every update, so:

- every update produces a different graph hash,
- the optimizer/backward graph is re-traced and recompiled,
- each compiled executable and its host-side metadata stays resident for the life of the process.

`total_timesteps: 10M` is ~9.7k updates, i.e. ~9.7k resident compilations — this matches the linear host-memory decline in the #609 chart, the crash at 800k–900k steps, and the fact that a process restart (checkpoint resume) resets it. The CPU path has no tracing, so changing a float lr is free there — matching the flat CPU baseline in the issue.

Everything else in the loop that could grow was checked and ruled out: the rollout buffer is a pre-allocated ring (`pos = (pos+1) % num_steps`), logging handles `.item()` scalars only, and wandb runs on both paths (CPU stays flat).

## The fix

Carry the lr as a **0-dim device tensor** on the TT path and update it in place (`copy_`) during annealing, so the traced graph — and its compilation — is reused. Adam is already constructed with `capturable=config.use_tt` on this path, which is exactly the mode that supports tensor lrs. CPU path behavior is unchanged.

```python
if config.use_tt:
    initial_lr = torch.tensor(config.learning_rate, device=device)
...
if config.anneal_lr:
    new_lr = config.learning_rate * frac
    if config.use_tt:
        optimizer.param_groups[0]["lr"].copy_(new_lr)
    else:
        optimizer.param_groups[0]["lr"] = new_lr
```

## Testing

No Wormhole hardware on my side, so the memory-profile claim needs a device run to confirm: short-run the yaml (reduced `total_timesteps`) with per-update `ru_maxrss` logging — before this change RSS should climb linearly per update, after it should stay flat. The change itself is mechanical (tensor lr + in-place update under `capturable=True`) and does not alter the CPU path.

Happy to iterate on the verification approach if maintainers prefer a different instrumentation.

Relates to #609
